### PR TITLE
Improve reliability of Zayo parser and add another test file for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.0.3
+## v1.1.0
+
+### Added
+
+- #16 - changed `MaintenanceNotification.raw` from `str` to `bytes`
 
 ## v1.0.2 - 2021-05-05
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,30 @@ Circuit Maintenance Notification #0
 }
 ```
 
+```bash
+$ circuit-maintenance-parser --raw-file tests/integration/data/zayo/zayo1.html --parser zayo
+Circuit Maintenance Notification #0
+{
+  "account": "clientX",
+  "circuits": [
+    {
+      "circuit_id": "/OGYX/000000/ /ZYO /",
+      "impact": "OUTAGE"
+    }
+  ],
+  "end": 1601035200,
+  "maintenance_id": "TTN-00000000",
+  "organizer": "mr@zayo.com",
+  "provider": "zayo",
+  "sequence": 1,
+  "stamp": 1599436800,
+  "start": 1601017200,
+  "status": "CONFIRMED",
+  "summary": "Zayo will implement planned maintenance to troubleshoot and restore degraded span",
+  "uid": "0"
+}
+```
+
 # Contributing
 
 Pull requests are welcomed and automatically built and tested against multiple versions of Python through Travis CI.

--- a/circuit_maintenance_parser/cli.py
+++ b/circuit_maintenance_parser/cli.py
@@ -15,16 +15,18 @@ from . import SUPPORTED_PROVIDER_PARSERS, init_parser, ParsingError
     default="ical",
     help="Parser type.",
 )
-def main(raw_file, parser):
+@click.option("-v", "--verbose", count=True, help="Increase logging verbosity (repeatable)")
+def main(raw_file, parser, verbose):
     """Entrypoint into CLI app."""
-    # TODO add verbosity flags to manage the logging level.
-    logging.basicConfig(level=logging.INFO)
+    # Default logging level is WARNING; specifying -v/--verbose repeatedly can lower the threshold.
+    verbosity = logging.WARNING - (10 * verbose)
+    logging.basicConfig(level=verbosity)
 
-    with open(raw_file) as raw_filename:
-        raw_text = raw_filename.read()
+    with open(raw_file, "rb") as raw_filename:
+        raw_bytes = raw_filename.read()
 
     data = {
-        "raw": raw_text,
+        "raw": raw_bytes,
         "provider_type": parser,
     }
 

--- a/circuit_maintenance_parser/cli.py
+++ b/circuit_maintenance_parser/cli.py
@@ -1,6 +1,9 @@
 """CLI for circuit-maintenance-parser."""
+import logging
 import sys
+
 import click
+
 from . import SUPPORTED_PROVIDER_PARSERS, init_parser, ParsingError
 
 
@@ -14,24 +17,28 @@ from . import SUPPORTED_PROVIDER_PARSERS, init_parser, ParsingError
 )
 def main(raw_file, parser):
     """Entrypoint into CLI app."""
+    # TODO add verbosity flags to manage the logging level.
+    logging.basicConfig(level=logging.INFO)
+
     with open(raw_file) as raw_filename:
         raw_text = raw_filename.read()
-        data = {
-            "raw": raw_text,
-            "provider_type": parser,
-        }
 
-        parser = init_parser(**data)
-        if not parser:
-            click.echo(f"Parser type {parser} is not supported.", err=True)
-            sys.exit(1)
+    data = {
+        "raw": raw_text,
+        "provider_type": parser,
+    }
 
-        try:
-            parsed_notifications = parser.process()
-        except ParsingError as parsing_error:
-            click.echo(f"Parsing failed: {parsing_error}", err=True)
-            sys.exit(1)
+    parser = init_parser(**data)
+    if not parser:
+        click.echo(f"Parser type {parser} is not supported.", err=True)
+        sys.exit(1)
 
-        for idx, parsed_notification in enumerate(parsed_notifications):
-            click.secho(f"Circuit Maintenance Notification #{idx}", fg="green", bold=True)
-            click.secho(parsed_notification.to_json(), fg="yellow")
+    try:
+        parsed_notifications = parser.process()
+    except ParsingError as parsing_error:
+        click.echo(f"Parsing failed: {parsing_error}", err=True)
+        sys.exit(1)
+
+    for idx, parsed_notification in enumerate(parsed_notifications):
+        click.secho(f"Circuit Maintenance Notification #{idx}", fg="green", bold=True)
+        click.secho(parsed_notification.to_json(), fg="yellow")

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -20,7 +20,7 @@ class MaintenanceNotification(BaseModel):
     This is the base class that is created from a Circuit Maintenance notification containing
 
     Attributes:
-        raw: Raw notification message
+        raw: Raw notification message (bytes)
         provider_type: Identifier of the provider of the notification
         sender: Identifier of the source of the notification (default "")
         subject: Subject of the notification (default "")
@@ -28,31 +28,29 @@ class MaintenanceNotification(BaseModel):
 
     Examples:
         >>> MaintenanceNotification(
-        ...     raw="raw_message",
+        ...     raw=b"raw_message",
         ...     sender="my_email@example.com",
         ...     subject="Urgent notification for circuits X and Y",
         ...     source="gmail",
         ...     provider_type="ntt",
         ... )
-        MaintenanceNotification(raw='raw_message', provider_type='ntt', sender='my_email@example.com', subject='Urgent notification for circuits X and Y', source='gmail')
+        MaintenanceNotification(raw=b'raw_message', provider_type='ntt', sender='my_email@example.com', subject='Urgent notification for circuits X and Y', source='gmail')
 
-        >>> MaintenanceNotification(raw="raw_message")
+        >>> MaintenanceNotification(raw=b"raw_message")
         Traceback (most recent call last):
         ...
         pydantic.error_wrappers.ValidationError: 1 validation error for MaintenanceNotification
         provider_type
           field required (type=value_error.missing)
 
-        >>> MaintenanceNotification("raw_message")
+        >>> MaintenanceNotification(b"raw_message")
         Traceback (most recent call last):
         ...
         TypeError: __init__() takes exactly 1 positional argument (2 given)
 
     """
 
-    # TODO: should `raw` actually be a bytes() rather than a str()? Let the parser decode to string
-    # if that's applicable to the particular data format being processed?
-    raw: str
+    raw: bytes
     provider_type: str
     sender: str = ""
     subject: str = ""

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -50,6 +50,8 @@ class MaintenanceNotification(BaseModel):
 
     """
 
+    # TODO: should `raw` actually be a bytes() rather than a str()? Let the parser decode to string
+    # if that's applicable to the particular data format being processed?
     raw: str
     provider_type: str
     sender: str = ""
@@ -185,4 +187,5 @@ class Html(MaintenanceNotification):
             line = line.text.strip()
         except AttributeError:
             line = line.strip()
+        # TODO: below may not be needed if we use `quopri.decodestring()` on the initial email file?
         return line.replace("=C2", "").replace("=A0", "").replace("\r", "").replace("=", "").replace("\n", "")

--- a/circuit_maintenance_parser/parsers/zayo.py
+++ b/circuit_maintenance_parser/parsers/zayo.py
@@ -32,9 +32,7 @@ class ParserZayo(Html):
             "organizer": self._default_organizer,
         }
         try:
-            # TODO: quopri requires a bytes input but self.raw is a str.
-            # For now we just encode it back to bytes ourself
-            soup = bs4.BeautifulSoup(quopri.decodestring(self.raw.encode()), features="lxml")
+            soup = bs4.BeautifulSoup(quopri.decodestring(self.raw), features="lxml")
             for line in soup.find_all("b"):
                 if isinstance(line, bs4.element.Tag):
                     if line.text.lower().strip().startswith("maintenance ticket #:"):
@@ -44,8 +42,10 @@ class ParserZayo(Html):
                         if urgency == "Planned":
                             data["status"] = Status("CONFIRMED")
                     elif "activity date" in line.text.lower():
+                        logger.info("Found 'activity date': %s", line.text)
                         for sibling in line.next_siblings:
                             text = sibling.text if isinstance(sibling, bs4.element.Tag) else sibling
+                            logger.debug("Checking for GMT date/timestamp in sibling: %s", text)
                             if "( GMT )" in text:
                                 window = self.clean_line(sibling).strip("( GMT )").split(" to ")
                                 start = parser.parse(window.pop(0))

--- a/circuit_maintenance_parser/parsers/zayo.py
+++ b/circuit_maintenance_parser/parsers/zayo.py
@@ -1,5 +1,8 @@
 """Zayo parser."""
+import logging
+import quopri
 from typing import Iterable, Union, Dict
+
 import bs4  # type: ignore
 import dateutil.parser as parser
 from pydantic import ValidationError
@@ -8,6 +11,9 @@ from circuit_maintenance_parser.errors import ParsingError, MissingMandatoryFiel
 from circuit_maintenance_parser.parser import Html, Impact, CircuitImpact, Maintenance, Status
 
 # pylint: disable=too-many-nested-blocks,no-member, too-many-branches
+
+
+logger = logging.getLogger(__name__)
 
 
 class ParserZayo(Html):
@@ -26,7 +32,9 @@ class ParserZayo(Html):
             "organizer": self._default_organizer,
         }
         try:
-            soup = bs4.BeautifulSoup(self.raw, features="lxml")
+            # TODO: quopri requires a bytes input but self.raw is a str.
+            # For now we just encode it back to bytes ourself
+            soup = bs4.BeautifulSoup(quopri.decodestring(self.raw.encode()), features="lxml")
             for line in soup.find_all("b"):
                 if isinstance(line, bs4.element.Tag):
                     if line.text.lower().strip().startswith("maintenance ticket #:"):
@@ -37,7 +45,8 @@ class ParserZayo(Html):
                             data["status"] = Status("CONFIRMED")
                     elif "activity date" in line.text.lower():
                         for sibling in line.next_siblings:
-                            if "( GMT )" in sibling.text:
+                            text = sibling.text if isinstance(sibling, bs4.element.Tag) else sibling
+                            if "( GMT )" in text:
                                 window = self.clean_line(sibling).strip("( GMT )").split(" to ")
                                 start = parser.parse(window.pop(0))
                                 data["start"] = self.dt2ts(start)
@@ -65,19 +74,20 @@ class ParserZayo(Html):
     def process_circuit_table(self, soup: bs4.BeautifulSoup) -> Iterable[CircuitImpact]:
         """Handles the circuit tables and returns a list of Circuit Impacts."""
         circuits = []
-        tables = soup.find("table")
+        tables = soup.find_all("table")
         for table in tables:
-            head_row = table.findAll("th")
-            if (
-                self.clean_line(head_row[0]) != "Circuit Id"
-                or self.clean_line(head_row[1]) != "Expected Impact"
-                or self.clean_line(head_row[2]) != "A Location CLLI"
-                or self.clean_line(head_row[3]) != "Z Location CLLI"
-                or self.clean_line(head_row[4]) != "Legacy Circuit Id"
-            ):
-                raise AssertionError("Table headers are not correct")
+            head_row = table.find_all("th")
+            if len(head_row) < 5 or [self.clean_line(line) for line in head_row[:5]] != [
+                "Circuit Id",
+                "Expected Impact",
+                "A Location CLLI",
+                "Z Location CLLI",
+                "Legacy Circuit Id",
+            ]:
+                logger.warning("Table headers are not as expected: %s", head_row)
+                continue
 
-            data_rows = table.findAll("td")
+            data_rows = table.find_all("td")
             if len(data_rows) % 5 != 0:
                 raise AssertionError("Table format is not correct")
             number_of_circuits = int(len(data_rows) / 5)

--- a/tests/integration/data/zayo/zayo2.html
+++ b/tests/integration/data/zayo/zayo2.html
@@ -1,0 +1,252 @@
+<html><font color=3D"FF0000" size=3D"4"><b>** Please note Cancellation of M=
+aintenance Notification **</b></font>
+<b>
+<br><br>Zayo Maintenance Notification
+<br><br>This email serves as official notification that Zayo and/or one of =
+its providers has cancelled the maintenance event listed below.
+</b>
+
+<br><br><b>Maintenance Ticket #: </b> TTN-0001234567
+
+<br><br><b>Urgency: </b> Planned
+
+<br><br><b>Date Notice Sent: </b> 26-Feb-2021
+
+<br><br><b>Customer: </b> Generic Account, Inc.
+
+<!-- <br><br><b>Maintenance Window: </b> 00:01 - 05:00 Central -->
+
+<br><br><b>Maintenance Window </b><br><br><b>1<sup>st</sup> Activity Date <=
+/b><br>27-Feb-2021 00:01 to 27-Feb-2021 05:00 ( Central )=20
+<br> 27-Feb-2021 06:00 to 27-Feb-2021 11:00 ( GMT )=20
+
+<br><br><b>Location of Maintenance: </b> 905 E 5th St, Newton, IA
+
+<br><br><b>Reason for Maintenance: </b> Zayo will implement network mainten=
+ance to enhance service reliability.
+
+<br><br><b>Expected Impact: </b> Service Affecting Activity:  Any Maintenan=
+ce Activity directly impacting the service(s) of customers. Service(s) are =
+expected to go down as a result of these activities.
+
+<br><br><b>Circuit(s) Affected: </b><br>
+<table border=3D3D"1"><tr>
+<tr>
+<th>Circuit Id</th>
+<th>Expected Impact</th>
+<th>A Location CLLI</th>
+
+<th>Z Location CLLI</th>
+<th>Legacy Circuit Id</th>
+</tr>
+<tr>
+<td>/XYZA/123456/   /ZYO /</td>
+<td>Hard Down - up to 1 hour</td>
+<td>ABCDEFGH</td>
+<td>IJKLMNOP</td>
+<td></td>
+</tr>
+</table>
+
+
+<br><br>Please contact the Zayo Maintenance Team with any questions regardi=
+ng this maintenance event. Please reference the Maintenance Ticket number w=
+hen calling.
+
+<br><br><b>Maintenance Team Contacts: </b><br><br>
+<div class=3DWordSection1>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white'><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#595959'>Zay</span></b><b><span style=3D'font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#FF8000'>o</span></b><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#595959'>&nbsp;Global Change Management Team/<span class=3DSpellE><i>=
+<span
+style=3D'background-image:initial;background-position:initial;background-re=
+peat:
+initial'>=C3=89quipe</i></span><i> de <span class=3DSpellE>Gestion</span> d=
+u <span
+class=3DSpellE>Changement</span> Global&nbsp;Zay</span></span></b><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#FF8000'>o</span></b></i><span style=3D'font-family:"Arial",sans-seri=
+f;
+color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'white-space:pre-wrap'><b><span style=3D'font-family:"Tr=
+ebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#F79646'>Zayo | Our Fiber Fuels Global Inn=
+ovation</span></span></b><span style=3D'font-family:"Arial",sans-serif;
+color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'>Toll free/<i>N<sup>o</sup>&nbsp;s=
+ans&nbsp;<span
+class=3DSpellE>frais</span>:</i>&nbsp;</span><span style=3D'font-size:11.0p=
+t;
+font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:blue=
+'>1.866.236.2824</span><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'>United Kingdom Toll Free/<i>N<sup=
+>o</sup>&nbsp;sans
+<span class=3DSpellE>frais</span> <span class=3DSpellE>Royaume-Uni</span>:<=
+/i>&nbsp;</span><span
+style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;mso-bidi-fo=
+nt-family:
+Arial;color:blue'>0800.169.1646</span><span style=3D'font-size:11.0pt;font-=
+family:
+"Arial",sans-serif;color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#222222;mso-ansi-language:FR'>Email/<i>Cou=
+rriel:</i>&nbsp;</span><u><span
+lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:blue;mso-ansi-language:FR'><a
+href=3D"mailto:releases@zayo.com" target=3D"_blank">mr@zayo.com</a></span><=
+/u><span
+lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222;mso-ansi-language:FR'>&nbsp;</span=
+><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span class=3DSpellE><span lang=3DFR-CA style=3D'font-size:11.0pt;font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222;mso-ansi=
+-language:
+FR-CA'>Website</span></span><span lang=3DFR style=3D'font-size:11.0pt;font-=
+family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222;mso-ansi=
+-language:
+FR'>/<i>Site Web:</i>&nbsp;<a href=3D"http://www.zayo.com/" target=3D"_blan=
+k">https://www.zayo.com</a></span><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-fam=
+ily:
+Arial;color:#222222'><a href=3D"http://www.zayo.com/company/about-zayo/"
+target=3D"_blank"><b><span style=3D'color:#ED7D31'>Purpose</span></b></a></=
+span><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;|&nbsp;</span><span style=3D'font-family:"Trebuchet MS=
+",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"http://www.zayo.com/solutions/global-network/" target=3D"_blank"><b=
+><span
+style=3D'color:#ED7D31'>Network Map</span></b></a></span><strong><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;</span></strong><span style=3D'font-family:"Trebuchet =
+MS",sans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>|&nbsp;</span><span style=3D'font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://tranzact.zayo.com/#!/escalation-lists" target=3D"_blank"><b=
+><span
+style=3D'color:#ED7D31'>Escalation List</span></b></a></span><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;</span></b><span style=3D'font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>|&nbsp;</span><span style=3D'font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://www.linkedin.com/company/530962/" target=3D"_blank"><b><spa=
+n
+style=3D'color:#ED7D31'>LinkedIn</span></b></a></span><b><span style=3D'fon=
+t-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#ED7D31'>&nbsp;<=
+/span></b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>|&nbsp;</span><span style=3D'font-family:"Trebuchet MS",sans=
+-serif;
+mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://twitter.com/zayogroup" target=3D"_blank"><b><span style=3D'=
+color:
+#ED7D31'>Twitter</span></b></a></span><b><span style=3D'font-family:"Trebuc=
+het MS",sans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>&nbsp;</span></b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>|&nbsp;<span class=3DSpellE><a
+href=3D"https://tranzact.zayo.com/#!/login" target=3D"_blank"><b><span
+style=3D'color:#ED7D31'>Tranzact</span></b><span style=3D'color:#ED7D31'>&n=
+bsp;</span></a></span></span><span
+style=3D'font-family:"Arial",sans-serif;color:#222222'><o:p></o:p></span></=
+p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-family:"Arial",sans-serif;color:#222222'><o:p>&nbs=
+p;</o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;word-spacing:
+0px'><b><i><span style=3D'font-size:9.0pt;font-family:"Trebuchet MS",sans-s=
+erif;
+mso-bidi-font-family:Arial;color:#7F7F7F'><span style=3D'white-space:pre-wr=
+ap'>This communication is the property of Zayo and may contain confidential=
+ or privileged information. If you have received this communication in erro=
+r, please promptly notify the sender by reply e-mail and destroy all copies=
+ of the communication and any attachments.</span></span></i></b><span style=
+=3D'font-size:
+10.0pt;font-family:"Arial",sans-serif;color:#222222'><o:p></o:p></span></p>
+
+<p class=3DMsoNormal><o:p>&nbsp;</o:p></p>
+
+</div></html>
+
+<p></p>

--- a/tests/integration/data/zayo/zayo2_result.json
+++ b/tests/integration/data/zayo/zayo2_result.json
@@ -1,0 +1,19 @@
+{
+  "account": "Generic Account, Inc.",
+  "circuits": [
+    {
+      "circuit_id": "/XYZA/123456/   /ZYO /",
+      "impact": "OUTAGE"
+    }
+  ],
+  "end": 1614423600,
+  "maintenance_id": "TTN-0001234567",
+  "organizer": "mr@zayo.com",
+  "provider": "zayo",
+  "sequence": 1,
+  "stamp": 1614297600,
+  "start": 1614405600,
+  "status": "CONFIRMED",
+  "summary": "Zayo will implement network maintenance to enhance service reliability.",
+  "uid": "0"
+}

--- a/tests/integration/test_eunetworks.py
+++ b/tests/integration/test_eunetworks.py
@@ -21,7 +21,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 )
 def test_complete_parsing(raw_file, results_file):
     """Tests for eunetworks parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ParserEUNetworks(raw=file_obj.read())
 
     parsed_notifications = parser.process()[0]

--- a/tests/integration/test_ical.py
+++ b/tests/integration/test_ical.py
@@ -24,7 +24,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 )
 def test_complete_parsing(raw_file, results_file):
     """Tests for Ical parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ICal(raw=file_obj.read())
 
     parsed_notifications = parser.process()[0]
@@ -47,7 +47,7 @@ def test_complete_parsing(raw_file, results_file):
 )
 def test_errored_parsing(raw_file, exception):
     """Tests for Ical parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ICal(raw=file_obj.read())
 
     with pytest.raises(exception):

--- a/tests/integration/test_ntt.py
+++ b/tests/integration/test_ntt.py
@@ -16,7 +16,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 )
 def test_complete_parsing(raw_file, results_file):
     """Tests for NTT parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ParserNTT(raw=file_obj.read())
 
     parsed_notifications = parser.process()[0]

--- a/tests/integration/test_packetfabric.py
+++ b/tests/integration/test_packetfabric.py
@@ -21,7 +21,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 )
 def test_complete_parsing(raw_file, results_file):
     """Tests for packetfabric parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ParserPacketFabric(raw=file_obj.read())
 
     parsed_notifications = parser.process()[0]

--- a/tests/integration/test_zayo.py
+++ b/tests/integration/test_zayo.py
@@ -6,14 +6,17 @@ from pathlib import Path
 import pytest
 
 from circuit_maintenance_parser.parsers.zayo import ParserZayo
-from circuit_maintenance_parser.errors import MissingMandatoryFields, ParsingError
+from circuit_maintenance_parser.errors import MissingMandatoryFields
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.mark.parametrize(
     "raw_file, results_file",
-    [(Path(dir_path, "data", "zayo", "zayo1.html"), Path(dir_path, "data", "zayo", "zayo1_result.json"),),],
+    [
+        (Path(dir_path, "data", "zayo", "zayo1.html"), Path(dir_path, "data", "zayo", "zayo1_result.json"),),
+        (Path(dir_path, "data", "zayo", "zayo2.html"), Path(dir_path, "data", "zayo", "zayo2_result.json"),),
+    ],
 )
 def test_complete_parsing(raw_file, results_file):
     """Tests for Zayo parser."""
@@ -33,7 +36,7 @@ def test_complete_parsing(raw_file, results_file):
     "raw_file, exception",
     [
         (Path(dir_path, "data", "zayo", "zayo_missing_maintenance_id.html"), MissingMandatoryFields,),
-        (Path(dir_path, "data", "zayo", "zayo_bad_html.html"), ParsingError,),
+        (Path(dir_path, "data", "zayo", "zayo_bad_html.html"), MissingMandatoryFields,),
     ],
 )
 def test_errored_parsing(raw_file, exception):

--- a/tests/integration/test_zayo.py
+++ b/tests/integration/test_zayo.py
@@ -20,7 +20,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 )
 def test_complete_parsing(raw_file, results_file):
     """Tests for Zayo parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ParserZayo(raw=file_obj.read())
 
     parsed_notifications = parser.process()[0]
@@ -41,7 +41,7 @@ def test_complete_parsing(raw_file, results_file):
 )
 def test_errored_parsing(raw_file, exception):
     """Tests for Ical parser."""
-    with open(raw_file) as file_obj:
+    with open(raw_file, "rb") as file_obj:
         parser = ParserZayo(raw=file_obj.read())
 
     with pytest.raises(exception):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -17,13 +17,13 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 @pytest.mark.parametrize(
     "raw, provider_type, result_type",
     [
-        ("raw_text", "wrong", None),
-        ("raw_text", "", ICal),
-        ("raw_text", "ical", ICal),
-        ("raw_text", "ntt", ParserNTT),
-        ("raw_text", "packetfabric", ParserPacketFabric),
-        ("raw_text", "eunetworks", ParserEUNetworks),
-        ("raw_text", "zayo", ParserZayo),
+        (b"raw_bytes", "wrong", None),
+        (b"raw_bytes", "", ICal),
+        (b"raw_bytes", "ical", ICal),
+        (b"raw_bytes", "ntt", ParserNTT),
+        (b"raw_bytes", "packetfabric", ParserPacketFabric),
+        (b"raw_bytes", "eunetworks", ParserEUNetworks),
+        (b"raw_bytes", "zayo", ParserZayo),
     ],
 )
 def test_init_parser(raw, provider_type, result_type):


### PR DESCRIPTION
- Add another lightly anonymized example Zayo notification email to integration tests
- Some minor code cleanup and a few TODOs to possibly revisit in a future PR
- Improve Zayo parser resilience:
  - Use [quopri](https://docs.python.org/3/library/quopri.html) to handle the `quoted-printable` encoding added to the original HTML content
  - Handle a few alternate cases that were initially causing exceptions to be thrown when I first attempted parsing this new file.