### PR TITLE
Fix default provider when not present in notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.1
+
+### Fix
+
+- #31 - Fix consistent provider (and other attributes) usage in all the classes
+
 ## v1.2.0 - 2021-06-21
 
 ### Added

--- a/circuit_maintenance_parser/__init__.py
+++ b/circuit_maintenance_parser/__init__.py
@@ -32,14 +32,13 @@ SUPPORTED_PROVIDER_NAMES = [provider.get_provider_type() for provider in SUPPORT
 SUPPORTED_ORGANIZER_EMAILS = [provider.get_default_organizer() for provider in SUPPORTED_PROVIDERS]
 
 
-def init_parser(**kwargs) -> Optional[GenericProvider]:
+def init_parser(raw, provider_type=None) -> Optional[GenericProvider]:
     """Returns an instance of the corresponding Notification Parser."""
     try:
-        provider_type = kwargs.get("provider_type")
         if not provider_type:
             provider_type = GenericProvider.get_provider_type()
         provider_parser_class = get_provider_class(provider_type)
-        return provider_parser_class(**kwargs)
+        return provider_parser_class(raw=raw)
 
     except NonexistentParserError:
         return None

--- a/circuit_maintenance_parser/output.py
+++ b/circuit_maintenance_parser/output.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 from typing import List, Optional
 
-from pydantic import BaseModel, validator, StrictStr, StrictInt
+from pydantic import BaseModel, validator, StrictStr, StrictInt, Extra
 
 
 class Impact(str, Enum):
@@ -49,7 +49,7 @@ class Status(str, Enum):
     RE_SCHEDULED = "RE-SCHEDULED"
 
 
-class CircuitImpact(BaseModel):
+class CircuitImpact(BaseModel, extra=Extra.forbid):
     """CircuitImpact class.
 
     Each Circuit Maintenance can contain multiple affected circuits, and each one can have a different level of impact.
@@ -88,7 +88,7 @@ class CircuitImpact(BaseModel):
         return value
 
 
-class Maintenance(BaseModel):
+class Maintenance(BaseModel, extra=Extra.forbid):
     """Maintenance class.
 
     Mandatory attributes:

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -134,10 +134,7 @@ class ICal(Parser):
                         ]
                     else:
                         data["circuits"] = [
-                            CircuitImpact(
-                                circuit_id=circuits,
-                                impact=Impact(component.get("X-MAINTNOTE-IMPACT")),
-                            )
+                            CircuitImpact(circuit_id=circuits, impact=Impact(component.get("X-MAINTNOTE-IMPACT")),)
                         ]
                     result.append(Maintenance(**data))
 

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -9,7 +9,7 @@ from typing import Iterable, Union, Dict, Mapping
 import bs4  # type: ignore
 from bs4.element import ResultSet  # type: ignore
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, Extra
 from icalendar import Calendar  # type: ignore
 
 from circuit_maintenance_parser.errors import ParsingError, MissingMandatoryFields
@@ -20,7 +20,7 @@ from circuit_maintenance_parser.output import Maintenance, Status, Impact, Circu
 logger = logging.getLogger(__name__)
 
 
-class Parser(BaseModel):
+class Parser(BaseModel, extra=Extra.forbid):
     """Parser class.
 
     Attributes:
@@ -134,7 +134,10 @@ class ICal(Parser):
                         ]
                     else:
                         data["circuits"] = [
-                            CircuitImpact(circuit_id=circuits, impact=Impact(component.get("X-MAINTNOTE-IMPACT")),)
+                            CircuitImpact(
+                                circuit_id=circuits,
+                                impact=Impact(component.get("X-MAINTNOTE-IMPACT")),
+                            )
                         ]
                     result.append(Maintenance(**data))
 

--- a/circuit_maintenance_parser/providers.py
+++ b/circuit_maintenance_parser/providers.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Iterable, Type
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 from circuit_maintenance_parser.output import Maintenance
 
@@ -19,14 +19,13 @@ from circuit_maintenance_parser.parsers.zayo import HtmlParserZayo1
 logger = logging.getLogger(__name__)
 
 
-class GenericProvider(BaseModel):
+class GenericProvider(BaseModel, extra=Extra.forbid):
     """Base class for the Providers Parsers.
 
     This is the base class that is created for a Circuit Maintenance Parser
 
     Attributes:
         raw: Raw notification message (bytes)
-        provider_type: Identifier of the provider of the notification
 
     Examples:
         >>> GenericProvider(

--- a/circuit_maintenance_parser/providers.py
+++ b/circuit_maintenance_parser/providers.py
@@ -68,7 +68,9 @@ class GenericProvider(BaseModel):
         for parser_class in self._parser_classes:
             try:
                 parser = parser_class(
-                    raw=self.raw, provider_type=self.get_provider_type(), default_organizer=self._default_organizer,
+                    raw=self.raw,
+                    default_provider=self.get_provider_type(),
+                    default_organizer=self.get_default_organizer(),
                 )
                 if data_type and data_type == parser.get_data_type() or not data_type:
                     return parser.process()

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -94,7 +94,9 @@ def test_complete_parsing(provider_class, raw_file, results_file):
     if provider_class == GenericProvider or raw_file == GENERIC_ICAL_DATA_PATH:
         expected_result["organizer"] = "mailto:noone@example.com"
     else:
-        expected_result["organizer"] = provider.get_default_organizer()
-        expected_result["provider"] = provider.get_provider_type()
+        if expected_result["organizer"] == "unknown":
+            expected_result["organizer"] = provider.get_default_organizer()
+        if expected_result["provider"] == "unknown":
+            expected_result["provider"] = provider.get_provider_type()
 
     assert json.loads(parsed_notifications.to_json()) == expected_result

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -95,5 +95,6 @@ def test_complete_parsing(provider_class, raw_file, results_file):
         expected_result["organizer"] = "mailto:noone@example.com"
     else:
         expected_result["organizer"] = provider.get_default_organizer()
+        expected_result["provider"] = provider.get_provider_type()
 
     assert json.loads(parsed_notifications.to_json()) == expected_result


### PR DESCRIPTION
The parsed response from a Provider was not taking the proper `provider` field when it was not present in the notifications, and the default name of the class was required. 
This PR adds the proper test to catch it and the fix.