### PR TITLE
Make Provider tests independent of particular Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,12 +216,11 @@ The project is following Network to Code software development guidelines and is 
 
 ### How to add a new Circuit Maintenance provider?
 
-1. If your Provider requires a custom parser, within `circuit_maintenance_parser/parsers`, **add your new parser**, inheriting from generic
-   `Parser` class or custom ones such as `ICal` or `Html` and add a **unit test for the new provider parser**, with at least one test case under
-   `tests/unit/data`.
-2. Add new class in `providers.py` with the custom info, defining in `_parser_classes` the list of parsers that you will use, using the generic `ICal` and/or your custom parsers.
-3. **Expose the new parser class** updating the map `SUPPORTED_PROVIDERS` in
-   `circuit_maintenance_parser/__init__.py` to officially expose the parser.
+1. Define the `Parsers`(inheriting from some of the generic `Parsers` or a new one) that will extract the data from the notification, that could contain itself multiple `DataParts`. The `data_type` of the `Parser` and the `DataPart` have to match. The custom `Parsers` will be placed in the `parsers` folder.
+2. Update the `unit/test_parsers.py` with the new parsers, providing some data to test and validate the extracted data.
+3. Define a new `Provider` inheriting from the `GenericProvider`, defining the `Processors` and the respective `Parsers` to be used. Maybe you can reuse some of the generic `Processors` or maybe you will need to create a custom one. If this is the case, place it in the `processors` folder.
+4. Update the `unit/test_e2e.py` with the new provider, providing some data to test and validate the final `Maintenances` created.
+5. **Expose the new `Provider` class** updating the map `SUPPORTED_PROVIDERS` in `circuit_maintenance_parser/__init__.py` to officially expose the `Provider`.
 
 ## Questions
 

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -5,29 +5,29 @@ import pytest
 
 from circuit_maintenance_parser.data import NotificationData
 from circuit_maintenance_parser.errors import ProcessorError, ProviderError
+from circuit_maintenance_parser.processor import SimpleProcessor
+from circuit_maintenance_parser.provider import GenericProvider
 
-# pylint: disable=duplicate-code
-from circuit_maintenance_parser.provider import (
-    GenericProvider,
-    Cogent,
-    EUNetworks,
-    Lumen,
-    Megaport,
-    NTT,
-    PacketFabric,
-    Telia,
-    Telstra,
-    Turkcell,
-    Verizon,
-    Zayo,
-)
 
 fake_data = NotificationData.init("fake_type", b"fake data")
 
 
+class ProviderWithOneProcessor(GenericProvider):
+    """Fake Provider with only one Processor."""
+
+
+class ProviderWithTwoProcessors(GenericProvider):
+    """Fake Provider with two Processors."""
+
+    _processors: List[GenericProcessor] = [
+        SimpleProcessor(),
+        SimpleProcessor(),
+    ]
+
+
 @pytest.mark.parametrize(
     "provider_class",
-    [GenericProvider, Cogent, EUNetworks, Lumen, Megaport, NTT, PacketFabric, Telia, Telstra, Turkcell, Verizon, Zayo,],
+    [ProviderWithOneProcessor, ProviderWithTwoProcessors],
 )
 def test_provide_get_maintenances(provider_class):
     """Tests GenericProvider."""
@@ -40,7 +40,7 @@ def test_provide_get_maintenances(provider_class):
 
 @pytest.mark.parametrize(
     "provider_class",
-    [GenericProvider, Cogent, EUNetworks, Lumen, Megaport, NTT, PacketFabric, Telia, Telstra, Turkcell, Verizon, Zayo,],
+    [ProviderWithOneProcessor, ProviderWithTwoProcessors],
 )
 def test_provide_get_maintenances_one_exception(provider_class):
     """Tests GenericProvider."""

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -7,6 +7,7 @@ from circuit_maintenance_parser.data import NotificationData
 from circuit_maintenance_parser.errors import ProcessorError, ProviderError
 from circuit_maintenance_parser.processor import SimpleProcessor
 from circuit_maintenance_parser.provider import GenericProvider
+from circuit_maintenance_parser.parser import Parser
 
 
 fake_data = NotificationData.init("fake_type", b"fake data")
@@ -19,15 +20,14 @@ class ProviderWithOneProcessor(GenericProvider):
 class ProviderWithTwoProcessors(GenericProvider):
     """Fake Provider with two Processors."""
 
-    _processors: List[GenericProcessor] = [
-        SimpleProcessor(),
-        SimpleProcessor(),
+    _processors = [
+        SimpleProcessor(data_parsers=[Parser]),
+        SimpleProcessor(data_parsers=[Parser]),
     ]
 
 
 @pytest.mark.parametrize(
-    "provider_class",
-    [ProviderWithOneProcessor, ProviderWithTwoProcessors],
+    "provider_class", [ProviderWithOneProcessor, ProviderWithTwoProcessors],
 )
 def test_provide_get_maintenances(provider_class):
     """Tests GenericProvider."""
@@ -39,8 +39,7 @@ def test_provide_get_maintenances(provider_class):
 
 
 @pytest.mark.parametrize(
-    "provider_class",
-    [ProviderWithOneProcessor, ProviderWithTwoProcessors],
+    "provider_class", [ProviderWithOneProcessor, ProviderWithTwoProcessors],
 )
 def test_provide_get_maintenances_one_exception(provider_class):
     """Tests GenericProvider."""


### PR DESCRIPTION
Provider tests should only test Provider methods logic, not particular Provider implementations, that are already tested in the End to End tests.