### PR TITLE
Extend email parsing support for encoded attachements

### DIFF
--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -24,7 +24,7 @@ def test_init_from_email_bytes():
         email_raw_data = email_file.read()
     data = NotificationData.init_from_email_bytes(email_raw_data)
     assert isinstance(data, NotificationData)
-    assert len(data.data_parts) == 7
+    assert len(data.data_parts) == 5
 
 
 def test_init_from_emailmessage():
@@ -35,4 +35,4 @@ def test_init_from_emailmessage():
     email_message = email.message_from_string(raw_email_string)
     data = NotificationData.init_from_emailmessage(email_message)
     assert isinstance(data, NotificationData)
-    assert len(data.data_parts) == 7
+    assert len(data.data_parts) == 5

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -42,7 +42,7 @@ def test_init_data_email():
         email_raw_data = email_file.read()
     data = init_data_email(email_raw_data)
     assert isinstance(data, NotificationData)
-    assert len(data.data_parts) == 7
+    assert len(data.data_parts) == 5
 
 
 def test_init_data_emailmessage():
@@ -53,7 +53,7 @@ def test_init_data_emailmessage():
     email_message = email.message_from_string(raw_email_string)
     data = init_data_emailmessage(email_message)
     assert isinstance(data, NotificationData)
-    assert len(data.data_parts) == 7
+    assert len(data.data_parts) == 5
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
While working on a new CSV parser, we found that we were not taking properly the payload data, so now we add the `decode=True` option

See: https://docs.python.org/3.5/library/email.message.html#email.message.Message.get_payload