### PR TITLE
Ensure that CombinedProcessor reinitializes self.combined_maintenance_data

### DIFF
--- a/circuit_maintenance_parser/processor.py
+++ b/circuit_maintenance_parser/processor.py
@@ -115,6 +115,10 @@ class CombinedProcessor(GenericProcessor):
     # The CombinedProcessor will consolidate all the parsed data into this variable
     combined_maintenance_data: Dict = {}
 
+    def process(self, data: NotificationData, extended_data: Dict) -> Iterable[Maintenance]:
+        self.combined_maintenance_data = {}
+        return super().process(data, extended_data)
+
     def process_hook(self, maintenances_extracted_data, maintenances_data):
         """All the parsers contribute with a subset of data that is extended.
 

--- a/circuit_maintenance_parser/processor.py
+++ b/circuit_maintenance_parser/processor.py
@@ -116,6 +116,7 @@ class CombinedProcessor(GenericProcessor):
     combined_maintenance_data: Dict = {}
 
     def process(self, data: NotificationData, extended_data: Dict) -> Iterable[Maintenance]:
+        """Extend base class process method to ensure that self.combined_maintenance_data is initialized correctly."""
         self.combined_maintenance_data = {}
         return super().process(data, extended_data)
 


### PR DESCRIPTION
Fixes #85 

The root cause was that for CombinedProcessor, `self.combined_maintenance_data` was only initialized at class instantiation time, meaning that when processing a second set of data using the same processor, any keys previously set on  `self.combined_maintenance_data` would bleed over from one processing to the next. The solution is to reinitialize this dictionary each time `process()` is called.