### PR TITLE
Defer loading of tzwhere until it's needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - #120 - Improve handling of Zayo notifications.
+- #121 - Defer loading of `tzwhere` data until it's needed, to reduce memory overhead.
 
 ## v2.0.6 - 2021-11-30
 


### PR DESCRIPTION
Fixes #121.

Instead of calling `tzwhere.tzwhere()` as a consequence of simply doing an `import circuit_maintenance_parser`, only call it when it's actually needed, by implementing it as a `classproperty` of the `Geolocator` class. Verified that this substantially reduces the baseline memory cost of `import circuit_maintenance_parser`.

I also explored replacing `tzwhere` with `timezonefinder`, which appears to be a more up-to-date, more memory-efficient fork, but found that while the peak memory cost of using `timezonefinder.TimezoneFinder()` instead of `tzwhere.tzwhere()` is much lower, `import timezonefinder` appears to cost about 20 MB more RAM than `import tzwhere`. So for the time being I didn't make that change, but we can revisit it if desired.