### PR TITLE
Add exclude filter for Telia

### DIFF
--- a/circuit_maintenance_parser/provider.py
+++ b/circuit_maintenance_parser/provider.py
@@ -301,6 +301,8 @@ class Sparkle(GenericProvider):
 class Telia(GenericProvider):
     """Telia provider custom class."""
 
+    _exclude_filter = {EMAIL_HEADER_SUBJECT: ["Disturbance Information"]}
+
     _default_organizer = "carrier-csc@teliacompany.com"
 
 


### PR DESCRIPTION
Exclude customer support emails from Telia that don't include a maintenance notification.