### PR TITLE
Handle Zayo table with "Customer Circuit ID" header

### DIFF
--- a/circuit_maintenance_parser/parsers/zayo.py
+++ b/circuit_maintenance_parser/parsers/zayo.py
@@ -128,6 +128,7 @@ class HtmlParserZayo1(Html):
             expected_headers_ref = (
                 ["Circuit Id", "Expected Impact", "A Location CLLI", "Z Location CLLI", "Legacy Circuit Id",],
                 ["Circuit Id", "Expected Impact", "A Location Address", "Z Location Address", "Legacy Circuit Id",],
+                ["Circuit Id", "Expected Impact", "A Location Address", "Z Location Address", "Customer Circuit Id",],
             )
             if all(table_headers != expected_headers for expected_headers in expected_headers_ref):
                 logger.warning("Table headers are not as expected: %s", head_row)

--- a/circuit_maintenance_parser/parsers/zayo.py
+++ b/circuit_maintenance_parser/parsers/zayo.py
@@ -128,7 +128,7 @@ class HtmlParserZayo1(Html):
             expected_headers_ref = (
                 ["Circuit Id", "Expected Impact", "A Location CLLI", "Z Location CLLI", "Legacy Circuit Id",],
                 ["Circuit Id", "Expected Impact", "A Location Address", "Z Location Address", "Legacy Circuit Id",],
-                ["Circuit Id", "Expected Impact", "A Location Address", "Z Location Address", "Customer Circuit Id",],
+                ["Circuit Id", "Expected Impact", "A Location Address", "Z Location Address", "Customer Circuit ID",],
             )
             if all(table_headers != expected_headers for expected_headers in expected_headers_ref):
                 logger.warning("Table headers are not as expected: %s", head_row)

--- a/tests/unit/data/zayo/zayo9.eml
+++ b/tests/unit/data/zayo/zayo9.eml
@@ -1,0 +1,599 @@
+Delivered-To: nautobot.email@example.com
+Received: by 2002:a05:7000:8c98:0:0:0:0 with SMTP id ja24csp175543mab;
+        Wed, 15 Dec 2021 09:55:52 -0800 (PST)
+X-Received: by 2002:a37:a590:: with SMTP id o138mr9453040qke.174.1639590952220;
+        Wed, 15 Dec 2021 09:55:52 -0800 (PST)
+ARC-Seal: i=3; a=rsa-sha256; t=1639590952; cv=pass;
+        d=google.com; s=arc-20160816;
+        b=hrMEsepR+6zON/Sb8A2hsoX5ERoCGGu/Ea1BQknvcz83ULsVozARTutuGJ4H3LMvMo
+         Kkg78ni2+qnFA2K8zYG7o7DWnuDruXWZBHdEu08HPqnt5TzHQSWonK/pgr1HlgLS9Gwl
+         /ww0Wp310E76A3Ceo/RPeYg8dK8wBcY/ZToj3eCf53v37yH5n/yEMzZNUiEfLJq/qYHi
+         mZdjnsUsC4VeQseGn5+LC58OL0o5iNVnuOKpHZu9tMcC6QKua0sTX0ma4cO6GM919vEx
+         46hywM+xqAG5jSf7sx3XapltdH337+lQ+dlIVbXTHA23fRCpqYYios6OMYvaTCbZE+IW
+         prVw==
+ARC-Message-Signature: i=3; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20160816;
+        h=list-unsubscribe:list-archive:list-help:list-post:list-id
+         :mailing-list:precedence:mime-version:subject:message-id:to:from
+         :date:sender:dkim-signature;
+        bh=EsaUguMqEmNO6jsjTZLhllzRn70aXLgPhX1LTHb3szs=;
+        b=KGIpzX5VYEwiFALcYj7d39n0653rIrsxc9FmBWuT+vWOLFidoxHdgF5QqUfwbccdoD
+         vQbyJgUos0XlQmu8ZJ1R5ALlBZRwZRFqGxuyRMjyyCxfGgcjOvGu2Dgogvu2C3mYGN/c
+         ZizkE5pMm4m2PLtPvU8Q+lUUk9PoyJ4LMcSJT3/YAMTatGZyXWuaRj3aQ8Q/ryiE7Uf3
+         uWG/LALzbEHov3nVjCkC9UbkoWJQvKWZtE3RC1lCX9h9+AIxrEU7vzFoLfBmKuiOArTq
+         tQlk8KgN+6Um7/EZyNlKlScSZb9I88+YGbdjOa8ruqUl/qh3CiVv67jC15CMuwWnP8Oa
+         78pw==
+ARC-Authentication-Results: i=3; mx.google.com;
+       dkim=pass header.i=@example.com header.s=example header.b="RQ/SNOat";
+       arc=pass (i=2 spf=pass spfdomain=gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com dkim=pass dkdomain=zayo.com dmarc=pass fromdomain=zayo.com);
+       spf=pass (google.com: domain of maint-notices+bncbcyp3io6yejbbjoy5cgqmgqeaidx5ui@example.com designates 209.85.220.97 as permitted sender) smtp.mailfrom=maint-notices+bncBCYP3IO6YEJBBJOY5CGQMGQEAIDX5UI@example.com;
+       dmarc=fail (p=NONE sp=NONE dis=NONE arc=pass) header.from=zayo.com
+Return-Path: <maint-notices+bncBCYP3IO6YEJBBJOY5CGQMGQEAIDX5UI@example.com>
+Received: from mail-sor-f97.google.com (mail-sor-f97.google.com. [209.85.220.97])
+        by mx.google.com with SMTPS id v19sor2882262qtk.22.2021.12.15.09.55.52
+        for <nautobot.email@example.com>
+        (Google Transport Security);
+        Wed, 15 Dec 2021 09:55:52 -0800 (PST)
+Received-SPF: pass (google.com: domain of maint-notices+bncbcyp3io6yejbbjoy5cgqmgqeaidx5ui@example.com designates 209.85.220.97 as permitted sender) client-ip=209.85.220.97;
+Authentication-Results: mx.google.com;
+       dkim=pass header.i=@example.com header.s=example header.b="RQ/SNOat";
+       arc=pass (i=2 spf=pass spfdomain=gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com dkim=pass dkdomain=zayo.com dmarc=pass fromdomain=zayo.com);
+       spf=pass (google.com: domain of maint-notices+bncbcyp3io6yejbbjoy5cgqmgqeaidx5ui@example.com designates 209.85.220.97 as permitted sender) smtp.mailfrom=maint-notices+bncBCYP3IO6YEJBBJOY5CGQMGQEAIDX5UI@example.com;
+       dmarc=fail (p=NONE sp=NONE dis=NONE arc=pass) header.from=zayo.com
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20210112;
+        h=x-gm-message-state:dkim-signature:sender:date:from:to:message-id
+         :subject:mime-version:x-original-sender
+         :x-original-authentication-results:precedence:mailing-list:list-id
+         :list-post:list-help:list-archive:list-unsubscribe;
+        bh=EsaUguMqEmNO6jsjTZLhllzRn70aXLgPhX1LTHb3szs=;
+        b=U35kqRteL2dyMHhmJacK3lRtBN2rBv95J1/Oi50dLrKmWd2m+ZHDN1KlZr0HU4/BV8
+         CjZCemq9Hj5BuvoTBKd/viX+2g4GXlBT2h/Myqh4NEnJhuIUMbpQVK3bKuvxiq2xPYiI
+         Crpo6Olq3FoLwC3nZM7HSWU4fvNQEl7TtAr+Eu1W2Heoz4IooDCLEFbH8G7pCERTl52C
+         qJKvx7wSdExujlb2Csk4a+grWJ0HvxjDu+ox1KpNdKzaRDv3Uw88/gRnkgh2mJeGGGwh
+         DH2S3QvSakZZ8YuXV4ifXkV1zxfM3X8J92kxF/mCruG7nOpmvYDNzKAY+zlveQf43ZVs
+         3yyw==
+X-Gm-Message-State: AOAM530OhsLiV4+N/8cyLABd8IVTmNajrnClhl3dh1eaNdl22oybfd84
+	Xmy20+FiS42QbZFEiUSZzPwAd89mpXqn2H9BszkrbGDtdKyi3Ibr
+X-Google-Smtp-Source: ABdhPJzIP+Tcum86b+hYiqifjsHFDpgUANUt/fvQy3xTZZ2462wLPl040DZx4DUyCYDvF9rLnCf5k0+jh5NR
+X-Received: by 2002:a05:622a:120b:: with SMTP id y11mr13317843qtx.544.1639590951871;
+        Wed, 15 Dec 2021 09:55:51 -0800 (PST)
+Return-Path: <maint-notices+bncBCYP3IO6YEJBBJOY5CGQMGQEAIDX5UI@example.com>
+Received: from netskope.com ([163.116.131.7])
+        by smtp-relay.gmail.com with ESMTPS id bs19sm1471710qkb.5.2021.12.15.09.55.51
+        for <nautobot.email@example.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 15 Dec 2021 09:55:51 -0800 (PST)
+X-Relaying-Domain: example.com
+Received: by mail-qk1-f200.google.com with SMTP id az44-20020a05620a172c00b0046a828b4684sf19504504qkb.22
+        for <nautobot.email@example.com>; Wed, 15 Dec 2021 09:55:50 -0800 (PST)
+ARC-Seal: i=2; a=rsa-sha256; t=1639590950; cv=pass;
+        d=google.com; s=arc-20160816;
+        b=oEYVVvyqeZEocJQFI211if2zYMDYP7NJfEEaZkWj7/MkctPubG5KuxBzru6RpiXUvJ
+         ezBV4gC68pK+yi9ZBz/H57l47fEcoupJYJVOB0wnWSxYZ5dv4WV5Il/X0eTNByNou2KO
+         9X3RU4dIl1PPgaXz/W5yngJJq2dc8ku0N13pFxhkrSAi231oYZPj7/sYOtmEsETg3rZv
+         YGbeLnmTr26xSzB4ciUJp9i1cPgfn8BpkWdgVMZIMzqTqlQyhs39ohf+DcVyWYyGsy5P
+         2KHGKj3kpXO7SLmYGIMgIPQ4/at9uCFIsg7BEk4nGJXNAAPza14v4G2ypToPWiyn6wYr
+         CjiQ==
+ARC-Message-Signature: i=2; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20160816;
+        h=list-unsubscribe:list-archive:list-help:list-post:list-id
+         :mailing-list:precedence:mime-version:subject:message-id:to:from
+         :date:sender:dkim-signature;
+        bh=EsaUguMqEmNO6jsjTZLhllzRn70aXLgPhX1LTHb3szs=;
+        b=a+4AdEV6r6dsPFYKK+1XQbIifwrAtywDFHebsE6fEqMyMBnU/s8Srwhh2BKlTcetm0
+         b0Mrx2j1JANUmzcHFBjG1gyQEuJo4Zfo57l4s4bL7AS7BxQ0ysI7H9F61Xe+KH0O6671
+         IzOTWpCA271zL0oUsB6qTOzY6l+2Ollbe5EzBMVnYkShzz32EYkB0AH+wMnpai2/bNsb
+         aWmSYOivX8gWohpP35VsUJzYhbXM+gchjkEe31DtkICR8ngosbDH1gQxTRoEDc7WaBN6
+         +NyabbmUUZgg8wwhXQLAFHTxnD5CSmQ9IKbhZybSd5qD3TpkaQwjnvexrf7EqixpGpOB
+         ZWrg==
+ARC-Authentication-Results: i=2; mx.google.com;
+       dkim=pass header.i=@zayo.com header.s=SF112018Alt header.b=CabAzYrd;
+       spf=pass (google.com: domain of mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com designates 13.110.74.206 as permitted sender) smtp.mailfrom="mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com";
+       dmarc=pass (p=NONE sp=NONE dis=NONE) header.from=zayo.com
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=example.com; s=example;
+        h=sender:date:from:to:message-id:subject:mime-version
+         :x-original-sender:x-original-authentication-results:precedence
+         :mailing-list:list-id:list-post:list-help:list-archive
+         :list-unsubscribe;
+        bh=EsaUguMqEmNO6jsjTZLhllzRn70aXLgPhX1LTHb3szs=;
+        b=RQ/SNOatNnKuDq/tvqH0xL78cnIeEtI0iNn2xm3HZN5BElxthAmLv3ZDlC1Xrly89i
+         OEpcQXlfQhM1js8x2vj0Iub8pN/nm+OMsnpknKknIqS7bFcCyLag8xetpjWlf6eyy9SA
+         xZyzgLQkXzCucJd7AaNYga1L2wXAoWQ5og3dY=
+Sender: maint-notices@example.com
+X-Received: by 2002:ac8:7009:: with SMTP id x9mr13099594qtm.420.1639590950056;
+        Wed, 15 Dec 2021 09:55:50 -0800 (PST)
+X-Received: by 2002:ac8:7009:: with SMTP id x9mr13099582qtm.420.1639590949877;
+        Wed, 15 Dec 2021 09:55:49 -0800 (PST)
+X-BeenThere: maint-notices@example.com
+Received: by 2002:a05:620a:1221:: with SMTP id v1ls1629089qkj.10.gmail; Wed,
+ 15 Dec 2021 09:55:49 -0800 (PST)
+X-Received: by 2002:a05:620a:24ca:: with SMTP id m10mr9238909qkn.635.1639590949194;
+        Wed, 15 Dec 2021 09:55:49 -0800 (PST)
+ARC-Seal: i=1; a=rsa-sha256; t=1639590949; cv=none;
+        d=google.com; s=arc-20160816;
+        b=jsxQeTSLo84+LRXwRqkN43jDoiCfDD2WtUhB22JsyEwZElP2cmR/Y1tiyIkS1pZ8X4
+         egJZYiM5jBC6bEo5zmbtpJ6XAAiPMD6aE226jRiV0UxmkayFVoGnqUCVpxdFt8taxCH1
+         yJIx2FFPSJPCh+CQ46Pqh+2r4UEaGHiHbJ90PCmzJI+PW0l9uIZHC3OaWOZBle3lyLJD
+         qwQdTNqXgAyfVCFyesI+k0cHBjwmmpKqB7Dq1ow0/o5FWWnner5UcdsawkXPfoAyzFYe
+         OxeFfRr8v/7zLWzRkFF62A+gxBAmxoepONnjaHOuLu3LK7REMx86Di6/kZwuhTU0Xfke
+         /PVw==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20160816;
+        h=mime-version:subject:message-id:to:from:date:dkim-signature;
+        bh=eWOdmKsULrJsBhon6OVLVL19FTKQGBJdsoJm7XAIBzc=;
+        b=EZM1DK57cQtRoIfOKN84XFpO2QhIWoJ48NboD0nxQpdhR6g0xrXsN6cl+wBZH6PMGI
+         yDRV7B7xvo3l3gApfPC96cSxTCq1TA9fF9RphZTr1OmUBIRTFOvRkBeA7PxbMzSkLcM2
+         YYn2KUkshVVT+WZ/MUMVTCvLfHSMDxcUkHxm4RjQLuRexqZ8sPy7J4iyY1zLCjwW//68
+         9wJ9xgEjXXtGdB8rF6cxDaaTqYX0bKXqnQZA08fc/ZVaG2Loc4k5UDIulJHE3U9U3N7T
+         JywUbmgu/NxDZDsCqfuZToM/4W4Dfle5OzQf1VJRKlISSS3JJyrCv6KiVWaOpqklErKk
+         h78w==
+ARC-Authentication-Results: i=1; mx.google.com;
+       dkim=pass header.i=@zayo.com header.s=SF112018Alt header.b=CabAzYrd;
+       spf=pass (google.com: domain of mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com designates 13.110.74.206 as permitted sender) smtp.mailfrom="mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com";
+       dmarc=pass (p=NONE sp=NONE dis=NONE) header.from=zayo.com
+Received: from smtp15-ia4-sp3.mta.salesforce.com (smtp15-ia4-sp3.mta.salesforce.com. [13.110.74.206])
+        by mx.google.com with ESMTPS id m4si1438845qkp.423.2021.12.15.09.55.49
+        for <maint-notices@example.com>
+        (version=TLS1_2 cipher=ECDHE-ECDSA-AES128-GCM-SHA256 bits=128/128);
+        Wed, 15 Dec 2021 09:55:49 -0800 (PST)
+Received-SPF: pass (google.com: domain of mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com designates 13.110.74.206 as permitted sender) client-ip=13.110.74.206;
+Received: from [10.180.203.108] ([10.180.203.108:41420] helo=na152-app2-8-ia4.ops.sfdc.net)
+	by mx1-ia4-sp3.mta.salesforce.com (envelope-from <mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com>)
+	(ecelerity 4.2.38.62368 r(Core:release/4.2.38.0)) with ESMTPS (cipher=ECDHE-RSA-AES256-GCM-SHA384
+	subject="/C=US/ST=California/L=San Francisco/O=salesforce.com, inc./OU=0:app;1:ia4;2:ia4-sp3;3:na152;4:prod/CN=na152-app2-8-ia4.ops.sfdc.net")
+	id 5A/FE-05444-42C2AB16; Wed, 15 Dec 2021 17:55:48 +0000
+Date: Wed, 15 Dec 2021 17:55:48 +0000 (GMT)
+From: MR Zayo <mr@zayo.com>
+To: "maint-notices@example.com" <maint-notices@example.com>
+Message-ID: <MbSVz000000000000000000000000000000000000000000000R464GQ00_GIDD_n0TA-lkO7LslKi6A@sfdc.net>
+Subject: [maint-notices] RESCHEDULE NOTIFICATION***Customer,inc***ZAYO
+ TTN-0001234567 Planned***
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_11347_523549970.1639590948797"
+X-Priority: 3
+X-SFDC-LK: 00D6000000079Qk
+X-SFDC-User: 005600000057Fhs
+X-Sender: postmaster@salesforce.com
+X-mail_abuse_inquiries: http://www.salesforce.com/company/abuse.jsp
+X-SFDC-TLS-NoRelay: 1
+X-SFDC-Binding: 1WrIRBV94myi25uB
+X-SFDC-EmailCategory: apiSingleMail
+X-SFDC-Interface: internal
+X-Original-Sender: mr@zayo.com
+X-Original-Authentication-Results: mx.google.com;       dkim=pass
+ header.i=@zayo.com header.s=SF112018Alt header.b=CabAzYrd;       spf=pass
+ (google.com: domain of mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com
+ designates 13.110.74.206 as permitted sender) smtp.mailfrom="mr=zayo.com__0-5kf7a5jav5y3ll@gkwgc1jp3j48nv.6-79qkeai.na152.bnc.salesforce.com";
+       dmarc=pass (p=NONE sp=NONE dis=NONE) header.from=zayo.com
+Precedence: list
+Mailing-list: list maint-notices@example.com; contact maint-notices+owners@example.com
+List-ID: <maint-notices.example.com>
+X-Google-Group-Id: 536184160288
+List-Post: <https://groups.google.com/a/example.com/group/maint-notices/post>, <mailto:maint-notices@example.com>
+List-Help: <https://support.google.com/a/example.com/bin/topic.py?topic=25838>,
+ <mailto:maint-notices+help@example.com>
+List-Archive: <https://groups.google.com/a/example.com/group/maint-notices/>
+List-Unsubscribe: <mailto:googlegroups-manage+536184160288+unsubscribe@googlegroups.com>,
+ <https://groups.google.com/a/example.com/group/maint-notices/subscribe>
+x-netskope-inspected: true
+
+------=_Part_11347_523549970.1639590948797
+Content-Type: multipart/alternative; 
+	boundary="----=_Part_11346_1620921427.1639590948797"
+
+------=_Part_11346_1620921427.1639590948797
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+** Please note revised Primary dates below **
+
+
+Reschedule Notification
+
+Zayo or one of its providers has rescheduled the maintenance listed below. =
+Please make a note of revised dates and times.
+
+
+
+Maintenance Ticket #: TTN-0001234567
+
+
+Urgency: Planned
+
+
+Date Notice Sent: 15-Dec-2021
+
+
+Customer: Customer,inc
+
+<!--=20
+
+Maintenance Window: 00:01 - 06:00 Eastern -->
+
+
+Maintenance Window=20
+
+1st Activity Date=20
+06-Jan-2022 00:01 to 06-Jan-2022 06:00 ( Eastern )=20
+
+ 06-Jan-2022 05:01 to 06-Jan-2022 11:00 ( GMT )=20
+
+2nd Activity Date=20
+07-Jan-2022 00:01 to 07-Jan-2022 06:00 ( Eastern )=20
+
+ 07-Jan-2022 05:01 to 07-Jan-2022 11:00 ( GMT )=20
+
+3rd Activity Date=20
+08-Jan-2022 00:01 to 08-Jan-2022 06:00 ( Eastern )=20
+
+ 08-Jan-2022 05:01 to 08-Jan-2022 11:00 ( GMT )=20
+
+
+
+Location of Maintenance: Some Street, Salmon Arm, BC
+
+
+Reason for Maintenance: Zayo Third-Party Provider will implement maintenanc=
+e to perform temporary fiber relocation in order to proactively avoid outag=
+es."Please Note" This is a reschedule of TTN-0002345678
+As this maintenance is not under the control of Zayo it may not be possible=
+ to reschedule it, due to resources having been coordinated with the railwa=
+y system (Lat: 50.12345- Lon: -119.12345)The maintenance consists of 2 nigh=
+ts; however, customers will only receive notification for the night their s=
+ervices will be impacted
+
+
+Expected Impact: Service Affecting Activity: Any Maintenance Activity direc=
+tly impacting the service(s) of customers. Service(s) are expected to go do=
+wn as a result of these activities.
+
+
+Circuit(s) Affected:=20
+
+
+Circuit Id
+Expected Impact
+A Location Address
+
+Z Location Address
+Customer Circuit Id
+
+/OQYX/234567/ /ZYO /
+Hard Down - up to 1 hour
+350 E Some Rd Chicago, IL. USA
+2020 Nth Ave Seattle, WA. USA
+
+
+
+
+Please contact the Zayo Maintenance Team with any questions regarding this =
+maintenance event. Please reference the Maintenance Ticket number when call=
+ing.
+
+
+Maintenance Team Contacts:=20
+
+
+
+
+Zayo=C2=A0Global Change Management Team/=C3=89quipe de Gestion du Changemen=
+t Global=C2=A0Zayo
+
+Zayo | Our Fiber Fuels Global Innovation
+
+Toll free/No=C2=A0sans=C2=A0frais:=C2=A01.866.236.2824
+
+United Kingdom Toll Free/No=C2=A0sans
+frais Royaume-Uni:=C2=A00800.169.1646
+
+Email/Courriel:=C2=A0mr@zayo.com=C2=A0
+
+Website/Site Web:=C2=A0https://www.zayo.com
+
+Purpose=C2=A0|=C2=A0Network Map=C2=A0|=C2=A0Escalation List=C2=A0|=C2=A0Lin=
+kedIn=C2=A0|=C2=A0Twitter=C2=A0|=C2=A0Tranzact=C2=A0
+
+=C2=A0
+
+This communication is the property of Zayo and may contain confidential or =
+privileged information. If you have received this communication in error, p=
+lease promptly notify the sender by reply e-mail and destroy all copies of =
+the communication and any attachments.
+
+=C2=A0
+
+--=20
+You received this message because you are subscribed to the Google Groups "=
+Maintenance Notices" group.
+To unsubscribe from this group and stop receiving emails from it, send an e=
+mail to maint-notices+unsubscribe@example.com.
+To view this discussion on the web visit https://groups.google.com/a/exampl=
+e.com/d/msgid/maint-notices/MbSVz0000000000000000000000000000000000000000000=
+00R464GQ00_GIDD_n0TA-lkO7LslKi6A%40sfdc.net.
+
+------=_Part_11346_1620921427.1639590948797
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<html><font color=3D"FF0000" size=3D"4"><b>** Please note revised Primary d=
+ates below **</b></font>
+<b>
+<br><br>Reschedule Notification
+<br><br>Zayo or one of its providers has rescheduled the maintenance listed=
+ below. Please make a note of revised dates and times.
+</b>
+
+<br><br><b>Maintenance Ticket #: </b> TTN-0001234567
+
+<br><br><b>Urgency: </b> Planned
+
+<br><br><b>Date Notice Sent: </b> 15-Dec-2021
+
+<br><br><b>Customer: </b> Customer,inc
+
+<!-- <br><br><b>Maintenance Window: </b> 00:01 - 06:00 Eastern -->
+
+<br><br><b>Maintenance Window </b><br><br><b>1<sup>st</sup> Activity Date <=
+/b><br>06-Jan-2022 00:01 to 06-Jan-2022 06:00 ( Eastern )=20
+<br> 06-Jan-2022 05:01 to 06-Jan-2022 11:00 ( GMT ) <br><br><b>2<sup>nd</su=
+p> Activity Date </b><br>07-Jan-2022 00:01 to 07-Jan-2022 06:00 ( Eastern )=
+=20
+<br> 07-Jan-2022 05:01 to 07-Jan-2022 11:00 ( GMT ) <br><br><b>3<sup>rd</su=
+p> Activity Date </b><br>08-Jan-2022 00:01 to 08-Jan-2022 06:00 ( Eastern )=
+=20
+<br> 08-Jan-2022 05:01 to 08-Jan-2022 11:00 ( GMT )=20
+
+
+<br><br><b>Location of Maintenance: </b> Some Street, Salmon Arm, BC
+
+<br><br><b>Reason for Maintenance: </b> Zayo Third-Party Provider will impl=
+ement maintenance to perform temporary fiber relocation in order to proacti=
+vely avoid outages."Please Note" This is a reschedule of TTN-0002345678
+As this maintenance is not under the control of  Zayo it may not be possibl=
+e to reschedule it, due to resources having been coordinated with the railw=
+ay system (Lat: 50.12345- Lon: -119.12345)The maintenance consists of 2 nig=
+hts; however, customers will only receive notification for the night their =
+services will be impacted
+
+<br><br><b>Expected Impact: </b> Service Affecting Activity:  Any Maintenan=
+ce Activity directly impacting the service(s) of customers. Service(s) are =
+expected to go down as a result of these activities.
+
+<br><br><b>Circuit(s) Affected: </b><br>
+<table border=3D3D"1"><tr>
+<tr>
+<th>Circuit Id</th>
+<th>Expected Impact</th>
+<th>A Location Address</th>
+
+<th>Z Location Address</th>
+<th>Customer Circuit Id</th>
+</tr>
+<tr>
+<td>/OQYX/234567/   /ZYO /</td>
+<td>Hard Down - up to 1 hour</td>
+<td>350 E Some Rd Chicago, IL. USA</td>
+<td>2020 Nth Ave Seattle, WA. USA</td>
+<td></td>
+</tr>
+</table>
+
+
+<br><br>Please contact the Zayo Maintenance Team with any questions regardi=
+ng this maintenance event. Please reference the Maintenance Ticket number w=
+hen calling.
+
+<br><br><b>Maintenance Team Contacts: </b><br><br>
+<div class=3DWordSection1>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white'><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#595959'>Zay</span></b><b><span style=3D'font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#FF8000'>o</span></b><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#595959'>&nbsp;Global Change Management Team/<span class=3DSpellE><i>=
+<span
+style=3D'background-image:initial;background-position:initial;background-re=
+peat:
+initial'>=C3=89quipe</i></span><i> de <span class=3DSpellE>Gestion</span> d=
+u <span
+class=3DSpellE>Changement</span> Global&nbsp;Zay</span></span></b><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#FF8000'>o</span></b></i><span style=3D'font-family:"Arial",sans-seri=
+f;
+color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'white-space:pre-wrap'><b><span style=3D'font-family:"Tr=
+ebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#F79646'>Zayo | Our Fiber Fuels Global Inn=
+ovation</span></span></b><span style=3D'font-family:"Arial",sans-serif;
+color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'>Toll free/<i>N<sup>o</sup>&nbsp;s=
+ans&nbsp;<span
+class=3DSpellE>frais</span>:</i>&nbsp;</span><span style=3D'font-size:11.0p=
+t;
+font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:blue=
+'>1.866.236.2824</span><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'>United Kingdom Toll Free/<i>N<sup=
+>o</sup>&nbsp;sans
+<span class=3DSpellE>frais</span> <span class=3DSpellE>Royaume-Uni</span>:<=
+/i>&nbsp;</span><span
+style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;mso-bidi-fo=
+nt-family:
+Arial;color:blue'>0800.169.1646</span><span style=3D'font-size:11.0pt;font-=
+family:
+"Arial",sans-serif;color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#222222;mso-ansi-language:FR'>Email/<i>Cou=
+rriel:</i>&nbsp;</span><u><span
+lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:blue;mso-ansi-language:FR'><a
+href=3D"mailto:releases@zayo.com" target=3D"_blank">mr@zayo.com</a></span><=
+/u><span
+lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222;mso-ansi-language:FR'>&nbsp;</span=
+><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span class=3DSpellE><span lang=3DFR-CA style=3D'font-size:11.0pt;font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222;mso-ansi=
+-language:
+FR-CA'>Website</span></span><span lang=3DFR style=3D'font-size:11.0pt;font-=
+family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222;mso-ansi=
+-language:
+FR'>/<i>Site Web:</i>&nbsp;<a href=3D"http://www.zayo.com/" target=3D"_blan=
+k">https://www.zayo.com</a></span><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-fam=
+ily:
+Arial;color:#222222'><a href=3D"http://www.zayo.com/company/about-zayo/"
+target=3D"_blank"><b><span style=3D'color:#ED7D31'>Purpose</span></b></a></=
+span><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;|&nbsp;</span><span style=3D'font-family:"Trebuchet MS=
+",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"http://www.zayo.com/solutions/global-network/" target=3D"_blank"><b=
+><span
+style=3D'color:#ED7D31'>Network Map</span></b></a></span><strong><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;</span></strong><span style=3D'font-family:"Trebuchet =
+MS",sans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>|&nbsp;</span><span style=3D'font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://tranzact.zayo.com/#!/escalation-lists" target=3D"_blank"><b=
+><span
+style=3D'color:#ED7D31'>Escalation List</span></b></a></span><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;</span></b><span style=3D'font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>|&nbsp;</span><span style=3D'font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://www.linkedin.com/company/530962/" target=3D"_blank"><b><spa=
+n
+style=3D'color:#ED7D31'>LinkedIn</span></b></a></span><b><span style=3D'fon=
+t-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#ED7D31'>&nbsp;<=
+/span></b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>|&nbsp;</span><span style=3D'font-family:"Trebuchet MS",sans=
+-serif;
+mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://twitter.com/zayogroup" target=3D"_blank"><b><span style=3D'=
+color:
+#ED7D31'>Twitter</span></b></a></span><b><span style=3D'font-family:"Trebuc=
+het MS",sans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>&nbsp;</span></b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>|&nbsp;<span class=3DSpellE><a
+href=3D"https://tranzact.zayo.com/#!/login" target=3D"_blank"><b><span
+style=3D'color:#ED7D31'>Tranzact</span></b><span style=3D'color:#ED7D31'>&n=
+bsp;</span></a></span></span><span
+style=3D'font-family:"Arial",sans-serif;color:#222222'><o:p></o:p></span></=
+p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-family:"Arial",sans-serif;color:#222222'><o:p>&nbs=
+p;</o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;word-spacing:
+0px'><b><i><span style=3D'font-size:9.0pt;font-family:"Trebuchet MS",sans-s=
+erif;
+mso-bidi-font-family:Arial;color:#7F7F7F'><span style=3D'white-space:pre-wr=
+ap'>This communication is the property of Zayo and may contain confidential=
+ or privileged information. If you have received this communication in erro=
+r, please promptly notify the sender by reply e-mail and destroy all copies=
+ of the communication and any attachments.</span></span></i></b><span style=
+=3D'font-size:
+10.0pt;font-family:"Arial",sans-serif;color:#222222'><o:p></o:p></span></p>
+
+<p class=3DMsoNormal><o:p>&nbsp;</o:p></p>
+
+</div></html>
+
+<p></p>
+
+-- <br />
+You received this message because you are subscribed to the Google Groups &=
+quot;Maintenance Notices&quot; group.<br />
+To unsubscribe from this group and stop receiving emails from it, send an e=
+mail to <a href=3D"mailto:maint-notices+unsubscribe@example.com">maint-notices+=
+unsubscribe@example.com</a>.<br />
+To view this discussion on the web visit <a href=3D"https://groups.google.c=
+om/a/example.com/d/msgid/maint-notices/MbSVz00000000000000000000000000000000=
+0000000000000R464GQ00_GIDD_n0TA-lkO7LslKi6A%40sfdc.net?utm_medium=3Demail&u=
+tm_source=3Dfooter">https://groups.google.com/a/example.com/d/msgid/maint-no=
+tices/MbSVz000000000000000000000000000000000000000000000R464GQ00_GIDD_n0TA-=
+lkO7LslKi6A%40sfdc.net</a>.<br />
+
+------=_Part_11346_1620921427.1639590948797--
+
+------=_Part_11347_523549970.1639590948797--

--- a/tests/unit/data/zayo/zayo9.eml
+++ b/tests/unit/data/zayo/zayo9.eml
@@ -256,7 +256,7 @@ Expected Impact
 A Location Address
 
 Z Location Address
-Customer Circuit Id
+Customer Circuit ID
 
 /OQYX/234567/ /ZYO /
 Hard Down - up to 1 hour
@@ -367,7 +367,7 @@ expected to go down as a result of these activities.
 <th>A Location Address</th>
 
 <th>Z Location Address</th>
-<th>Customer Circuit Id</th>
+<th>Customer Circuit ID</th>
 </tr>
 <tr>
 <td>/OQYX/234567/   /ZYO /</td>

--- a/tests/unit/data/zayo/zayo9_html_parser_result.json
+++ b/tests/unit/data/zayo/zayo9_html_parser_result.json
@@ -1,0 +1,17 @@
+[
+    {
+        "account": "Customer,inc",
+        "circuits": [
+            {
+                "circuit_id": "/OQYX/234567/   /ZYO /",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1641639600,
+        "maintenance_id": "TTN-0001234567",
+        "stamp": 1639526400,
+        "start": 1641445260,
+        "status": "RE-SCHEDULED",
+        "summary": "Zayo Third-Party Provider will implement maintenance to perform temporary fiber relocation in order to proactively avoid outages.\"Please Note\" This is a reschedule of TTN-0002345678\r\nAs this maintenance is not under the control of  Zayo it may not be possible to reschedule it, due to resources having been coordinated with the railway system (Lat: 50.12345- Lon: -119.12345)The maintenance consists of 2 nights; however, customers will only receive notification for the night their services will be impacted"
+    }
+]

--- a/tests/unit/data/zayo/zayo9_result.json
+++ b/tests/unit/data/zayo/zayo9_result.json
@@ -1,0 +1,21 @@
+[
+    {
+        "account": "Customer,inc",
+        "circuits": [
+            {
+                "circuit_id": "/OQYX/234567/   /ZYO /",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1641639600,
+        "maintenance_id": "TTN-0001234567",
+        "organizer": "mr@zayo.com",
+        "provider": "zayo",
+        "sequence": 1,
+        "stamp": 1639526400,
+        "start": 1641445260,
+        "status": "RE-SCHEDULED",
+        "summary": "Zayo Third-Party Provider will implement maintenance to perform temporary fiber relocation in order to proactively avoid outages.\"Please Note\" This is a reschedule of TTN-0002345678\r\nAs this maintenance is not under the control of  Zayo it may not be possible to reschedule it, due to resources having been coordinated with the railway system (Lat: 50.12345- Lon: -119.12345)The maintenance consists of 2 nights; however, customers will only receive notification for the night their services will be impacted",
+        "uid": "0"
+    }
+]

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -571,6 +571,11 @@ GENERIC_ICAL_RESULT_PATH = Path(dir_path, "data", "ical", "ical1_result.json")
             [("email", Path(dir_path, "data", "zayo", "zayo8.eml")),],
             [Path(dir_path, "data", "zayo", "zayo8_result.json"),],
         ),
+        (
+            Zayo,
+            [("email", Path(dir_path, "data", "zayo", "zayo9.eml")),],
+            [Path(dir_path, "data", "zayo", "zayo9_result.json"),],
+        ),
     ],
 )
 def test_provider_get_maintenances(

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -468,6 +468,11 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
             Path(dir_path, "data", "zayo", "zayo8_subject.txt"),
             Path(dir_path, "data", "zayo", "zayo8_subject_parser_result.json"),
         ),
+        (
+            HtmlParserZayo1,
+            Path(dir_path, "data", "zayo", "zayo9.eml"),
+            Path(dir_path, "data", "zayo", "zayo9_html_parser_result.json"),
+        ),
         # Email Date
         (
             EmailDateParser,


### PR DESCRIPTION
This handles a case where the Zayo table uses "Customer Circuit ID" in the header rather than "Legacy Circuit ID", which caused the parser to crash.