### PR TITLE
added chardet encoding detection in filer_check

### DIFF
--- a/circuit_maintenance_parser/provider.py
+++ b/circuit_maintenance_parser/provider.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import traceback
+import chardet
 
 from typing import Iterable, List, Dict
 
@@ -95,7 +96,8 @@ class GenericProvider(BaseModel):
             if filter_data_type not in filter_dict:
                 continue
 
-            data_part_content = data_part.content.decode().replace("\r", "").replace("\n", "")
+            data_part_encoding = chardet.detect(data_part.content).get("encoding", "utf-8")
+            data_part_content = data_part.content.decode(data_part_encoding).replace("\r", "").replace("\n", "")
             if any(re.search(filter_re, data_part_content) for filter_re in filter_dict[filter_data_type]):
                 logger.debug("Matching %s filter expression for %s.", filter_type, data_part_content)
                 return True

--- a/circuit_maintenance_parser/provider.py
+++ b/circuit_maintenance_parser/provider.py
@@ -2,9 +2,9 @@
 import logging
 import re
 import traceback
-import chardet
 
 from typing import Iterable, List, Dict
+import chardet
 
 from pydantic import BaseModel
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,6 +131,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "chardet"
+version = "5.0.0"
+description = "Universal encoding detector for Python 3"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -185,7 +193,7 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc9"
+version = "1.0.1"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -261,7 +269,7 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""
 
 [[package]]
 name = "icalendar"
-version = "5.0.1"
+version = "5.0.2"
 description = "iCalendar parser/generator"
 category = "main"
 optional = false
@@ -328,11 +336,11 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "lazy-object-proxy"
-version = "1.7.1"
+version = "1.8.0"
 description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "lxml"
@@ -592,7 +600,7 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
-version = "2022.5"
+version = "2022.6"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -642,7 +650,7 @@ test = ["fixtures", "mock", "purl", "pytest", "requests-futures", "sphinx", "tes
 
 [[package]]
 name = "setuptools"
-version = "65.5.0"
+version = "65.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -650,7 +658,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -744,7 +752,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-pytz"
-version = "2022.5.0.0"
+version = "2022.6.0.1"
 description = "Typing stubs for pytz"
 category = "dev"
 optional = false
@@ -826,7 +834,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "193ba856f1243b9862ab6ea41ede2120520def59eee9bf4b00a8040510753494"
+content-hash = "b4043a36927c2d6225e8be401ce9fd95324ff3aa91119c56b74984e0219458ac"
 
 [metadata.files]
 astroid = [
@@ -901,6 +909,10 @@ certifi = [
     {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
     {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
 ]
+chardet = [
+    {file = "chardet-5.0.0-py3-none-any.whl", hash = "sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557"},
+    {file = "chardet-5.0.0.tar.gz", hash = "sha256:0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
     {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
@@ -921,8 +933,8 @@ dill = [
     {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
-    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+    {file = "exceptiongroup-1.0.1-py3-none-any.whl", hash = "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a"},
+    {file = "exceptiongroup-1.0.1.tar.gz", hash = "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
@@ -945,8 +957,8 @@ gitpython = [
     {file = "GitPython-3.1.29.tar.gz", hash = "sha256:cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd"},
 ]
 icalendar = [
-    {file = "icalendar-5.0.1-py3-none-any.whl", hash = "sha256:41f2f450707a503365a81c22954be4053779994c8ff01fc11bf4ce33a724092e"},
-    {file = "icalendar-5.0.1.tar.gz", hash = "sha256:35faeae20e58d0fe26e33c04bbfd08b424192d61ae3e1da1d7611ba06ab33570"},
+    {file = "icalendar-5.0.2-py3-none-any.whl", hash = "sha256:2eefb4765286086afb9b5ed41c121c7b59d934567990982b60bb3edbca9922bc"},
+    {file = "icalendar-5.0.2.tar.gz", hash = "sha256:edc635fd9334102d409f4571fb953ef0f84ce01dd15ff83cac6afafe89c8e56a"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -969,43 +981,25 @@ isort = [
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 lazy-object-proxy = [
-    {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win32.whl", hash = "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win32.whl", hash = "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
-    {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
+    {file = "lazy-object-proxy-1.8.0.tar.gz", hash = "sha256:c219a00245af0f6fa4e95901ed28044544f50152840c5b6a3e7b2568db34d156"},
+    {file = "lazy_object_proxy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4fd031589121ad46e293629b39604031d354043bb5cdf83da4e93c2d7f3389fe"},
+    {file = "lazy_object_proxy-1.8.0-cp310-cp310-win32.whl", hash = "sha256:b70d6e7a332eb0217e7872a73926ad4fdc14f846e85ad6749ad111084e76df25"},
+    {file = "lazy_object_proxy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:eb329f8d8145379bf5dbe722182410fe8863d186e51bf034d2075eb8d85ee25b"},
+    {file = "lazy_object_proxy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4e2d9f764f1befd8bdc97673261b8bb888764dfdbd7a4d8f55e4fbcabb8c3fb7"},
+    {file = "lazy_object_proxy-1.8.0-cp311-cp311-win32.whl", hash = "sha256:e20bfa6db17a39c706d24f82df8352488d2943a3b7ce7d4c22579cb89ca8896e"},
+    {file = "lazy_object_proxy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:14010b49a2f56ec4943b6cf925f597b534ee2fe1f0738c84b3bce0c1a11ff10d"},
+    {file = "lazy_object_proxy-1.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6850e4aeca6d0df35bb06e05c8b934ff7c533734eb51d0ceb2d63696f1e6030c"},
+    {file = "lazy_object_proxy-1.8.0-cp37-cp37m-win32.whl", hash = "sha256:5b51d6f3bfeb289dfd4e95de2ecd464cd51982fe6f00e2be1d0bf94864d58acd"},
+    {file = "lazy_object_proxy-1.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:6f593f26c470a379cf7f5bc6db6b5f1722353e7bf937b8d0d0b3fba911998858"},
+    {file = "lazy_object_proxy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c1c7c0433154bb7c54185714c6929acc0ba04ee1b167314a779b9025517eada"},
+    {file = "lazy_object_proxy-1.8.0-cp38-cp38-win32.whl", hash = "sha256:d176f392dbbdaacccf15919c77f526edf11a34aece58b55ab58539807b85436f"},
+    {file = "lazy_object_proxy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:afcaa24e48bb23b3be31e329deb3f1858f1f1df86aea3d70cb5c8578bfe5261c"},
+    {file = "lazy_object_proxy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:71d9ae8a82203511a6f60ca5a1b9f8ad201cac0fc75038b2dc5fa519589c9288"},
+    {file = "lazy_object_proxy-1.8.0-cp39-cp39-win32.whl", hash = "sha256:8f6ce2118a90efa7f62dd38c7dbfffd42f468b180287b748626293bf12ed468f"},
+    {file = "lazy_object_proxy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:eac3a9a5ef13b332c059772fd40b4b1c3d45a3a2b05e33a361dee48e54a4dad0"},
+    {file = "lazy_object_proxy-1.8.0-pp37-pypy37_pp73-any.whl", hash = "sha256:ae032743794fba4d171b5b67310d69176287b5bf82a21f588282406a79498891"},
+    {file = "lazy_object_proxy-1.8.0-pp38-pypy38_pp73-any.whl", hash = "sha256:7e1561626c49cb394268edd00501b289053a652ed762c58e1081224c8d881cec"},
+    {file = "lazy_object_proxy-1.8.0-pp39-pypy39_pp73-any.whl", hash = "sha256:ce58b2b3734c73e68f0e30e4e725264d4d6be95818ec0a0be4bb6bf9a7e79aa8"},
 ]
 lxml = [
     {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
@@ -1198,8 +1192,8 @@ python-dotenv = [
     {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
 ]
 pytz = [
-    {file = "pytz-2022.5-py2.py3-none-any.whl", hash = "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"},
-    {file = "pytz-2022.5.tar.gz", hash = "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"},
+    {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},
+    {file = "pytz-2022.6.tar.gz", hash = "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1252,8 +1246,8 @@ requests-mock = [
     {file = "requests_mock-1.10.0-py2.py3-none-any.whl", hash = "sha256:2fdbb637ad17ee15c06f33d31169e71bf9fe2bdb7bc9da26185be0dd8d842699"},
 ]
 setuptools = [
-    {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
-    {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
+    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
+    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
 ]
 shapely = [
     {file = "Shapely-1.8.5.post1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d048f93e42ba578b82758c15d8ae037d08e69d91d9872bca5a1895b118f4e2b0"},
@@ -1355,8 +1349,8 @@ types-python-dateutil = [
     {file = "types_python_dateutil-2.8.19.2-py3-none-any.whl", hash = "sha256:3f4dbe465e7e0c6581db11fd7a4855d1355b78712b3f292bd399cd332247e9c0"},
 ]
 types-pytz = [
-    {file = "types-pytz-2022.5.0.0.tar.gz", hash = "sha256:0c163b15d3e598e6cc7074a99ca9ec72b25dc1b446acc133b827667af0b7b09a"},
-    {file = "types_pytz-2022.5.0.0-py3-none-any.whl", hash = "sha256:a8e1fe6a1b270fbfaf2553b20ad0f1316707cc320e596da903bb17d7373fed2d"},
+    {file = "types-pytz-2022.6.0.1.tar.gz", hash = "sha256:d078196374d1277e9f9984d49373ea043cf2c64d5d5c491fbc86c258557bd46f"},
+    {file = "types_pytz-2022.6.0.1-py3-none-any.whl", hash = "sha256:bea605ce5d5a5d52a8e1afd7656c9b42476e18a0f888de6be91587355313ddf4"},
 ]
 types-toml = [
     {file = "types-toml-0.10.8.tar.gz", hash = "sha256:b7e7ea572308b1030dc86c3ba825c5210814c2825612ec679eb7814f8dd9295a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -452,15 +452,15 @@ python-versions = ">=2.6"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "2.5.3"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -743,6 +743,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-chardet"
+version = "5.0.4"
+description = "Typing stubs for chardet"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.8.19.2"
 description = "Typing stubs for python-dateutil"
@@ -834,7 +842,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b4043a36927c2d6225e8be401ce9fd95324ff3aa91119c56b74984e0219458ac"
+content-hash = "2ddc7c2009ec0ea1affb5b8a7e83ac678a09f7c19877398aa3d25b77deba6b51"
 
 [metadata.files]
 astroid = [
@@ -1128,8 +1136,8 @@ pbr = [
     {file = "pbr-5.11.0.tar.gz", hash = "sha256:b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+    {file = "platformdirs-2.5.3-py3-none-any.whl", hash = "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb"},
+    {file = "platformdirs-2.5.3.tar.gz", hash = "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -1343,6 +1351,10 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+types-chardet = [
+    {file = "types-chardet-5.0.4.tar.gz", hash = "sha256:449a98338fa264ddee88dd3a8141989f0ae920bcc720460c54b9f4374a6c1bb3"},
+    {file = "types_chardet-5.0.4-py3-none-any.whl", hash = "sha256:6946e22f32789a473852570810b4afe632172fae03c04bdbffe670606cc4ac11"},
 ]
 types-python-dateutil = [
     {file = "types-python-dateutil-2.8.19.2.tar.gz", hash = "sha256:e6e32ce18f37765b08c46622287bc8d8136dc0c562d9ad5b8fd158c59963d7a7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -746,13 +746,13 @@ python-versions = ">=3.6"
 name = "types-chardet"
 version = "5.0.4"
 description = "Typing stubs for chardet"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.8.19.2"
+version = "2.8.19.3"
 description = "Typing stubs for python-dateutil"
 category = "dev"
 optional = false
@@ -842,7 +842,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2ddc7c2009ec0ea1affb5b8a7e83ac678a09f7c19877398aa3d25b77deba6b51"
+content-hash = "dfcb07ac46d5d695fe7fdddab30146d42783d5e6df85c90a55fdee3e440b86b2"
 
 [metadata.files]
 astroid = [
@@ -1357,8 +1357,8 @@ types-chardet = [
     {file = "types_chardet-5.0.4-py3-none-any.whl", hash = "sha256:6946e22f32789a473852570810b4afe632172fae03c04bdbffe670606cc4ac11"},
 ]
 types-python-dateutil = [
-    {file = "types-python-dateutil-2.8.19.2.tar.gz", hash = "sha256:e6e32ce18f37765b08c46622287bc8d8136dc0c562d9ad5b8fd158c59963d7a7"},
-    {file = "types_python_dateutil-2.8.19.2-py3-none-any.whl", hash = "sha256:3f4dbe465e7e0c6581db11fd7a4855d1355b78712b3f292bd399cd332247e9c0"},
+    {file = "types-python-dateutil-2.8.19.3.tar.gz", hash = "sha256:a313284df5ed3fd078303262edc0efde28998cd08e5061ef1ccc0bb5fef4d2da"},
+    {file = "types_python_dateutil-2.8.19.3-py3-none-any.whl", hash = "sha256:ce6af1bdf0aca6b7dc8815a664f0e8b55da91ff7851102cf87c87178e7c8e7ec"},
 ]
 types-pytz = [
     {file = "types-pytz-2022.6.0.1.tar.gz", hash = "sha256:d078196374d1277e9f9984d49373ea043cf2c64d5d5c491fbc86c258557bd46f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ lxml = "^4.6.2"
 geopy = "^2.1.0"
 tzwhere = "^3.0.3"
 backoff = "^1.11.1"
+chardet = "^5.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ geopy = "^2.1.0"
 tzwhere = "^3.0.3"
 backoff = "^1.11.1"
 chardet = "^5"
-types-chardet = "^5.0.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"
@@ -53,6 +52,7 @@ types-pytz = "^2022.0.0"
 types-toml = "^0.10.1"
 netconan = "^0.12.3"
 toml = "0.10.2"
+types-chardet = "^5.0.4"
 
 [tool.poetry.scripts]
 circuit-maintenance-parser = "circuit_maintenance_parser.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ lxml = "^4.6.2"
 geopy = "^2.1.0"
 tzwhere = "^3.0.3"
 backoff = "^1.11.1"
-chardet = "^5.0.0"
+chardet = "^5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ geopy = "^2.1.0"
 tzwhere = "^3.0.3"
 backoff = "^1.11.1"
 chardet = "^5"
+types-chardet = "^5.0.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"

--- a/tests/unit/data/zayo/zayo10.eml
+++ b/tests/unit/data/zayo/zayo10.eml
@@ -1,0 +1,383 @@
+Date: Tue, 18 Oct 2022 22:45:34 +0000 (GMT)
+From: MR Zayo <mr@zayo.com>
+To: "foo@example.com" <foo@example.com>
+Message-ID: <2j1fn000000000000000000000000000000000000000000000RJZ0JO00LiATa74-RmmR2r@sfdc.net>
+Subject: ***Customer,inc***ZAYO TTN-0001234567 Emergency
+ MAINTENANCE NOTIFICATION***
+MIME-Version: 1.0
+Content-Type: multipart/mixed; 
+	boundary="----=_Part_14359_801717674.1666133134471"
+X-Priority: 3
+X-SFDC-LK: 00D6000000079Qk
+X-SFDC-User: 0054z000008sWbJ
+X-Sender: postmaster@salesforce.com
+X-mail_abuse_inquiries: http://www.salesforce.com/company/abuse.jsp
+X-SFDC-TLS-NoRelay: 1
+X-SFDC-Binding: 1WrIRBV94myi25uB
+X-SFDC-EmailCategory: apiSingleMailViaApex
+X-SFDC-Interface: internal
+X-Original-Sender: mr@zayo.com
+X-Original-Authentication-Results: mx.google.com;       dkim=pass
+ header.i=@zayo.com header.s=SF112018Alt header.b=iG8OeIBq;       spf=pass
+ (google.com: domain of mr=zayo.com__2ff706eokfxkk5lh@vthkfkgg0skc.6-79qkeai.na152.bnc.salesforce.com
+ designates 13.110.78.205 as permitted sender) smtp.mailfrom="mr=zayo.com__2ff706eokfxkk5lh@vthkfkgg0skc.6-79qkeai.na152.bnc.salesforce.com";
+       dmarc=pass (p=NONE sp=NONE dis=NONE) header.from=zayo.com
+
+------=_Part_14359_801717674.1666133134471
+Content-Type: multipart/alternative; 
+	boundary="----=_Part_14358_1498340646.1666133134471"
+
+------=_Part_14358_1498340646.1666133134471
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+Zayo Maintenance Notification=20
+
+
+This email serves as official notification that Zayo and/or one of its prov=
+iders will be performing maintenance on its network as described below. Thi=
+s maintenance may affect services you have with us.
+
+
+
+Maintenance Ticket #: TTN-0001234567
+
+
+Urgency: Emergency
+
+
+Date Notice Sent: 18-Oct-2022
+
+
+Customer: Customer,inc
+
+<!--=20
+
+Maintenance Window: 19:00 - 01:00 Central -->
+
+
+Maintenance Window=20
+
+1st Activity Date=20
+18-Oct-2022 19:00 to 19-Oct-2022 01:00 ( Central )=20
+
+ 19-Oct-2022 00:00 to 19-Oct-2022 06:00 ( GMT )=20
+
+
+Location of Maintenance: NE
+
+
+Reason for Maintenance: Zayo will implement EÉmergency maintenance to restore network stability and prevent an unplanned outage.
+Expected Impact: Service Affecting Activity: Any Maintenance Activity directly impacting the service(s) of customers. Service(s) are expected to go down as a result of these activities.
+
+
+Circuit(s) Affected:=20
+
+
+Circuit Id
+Expected Impact
+A Location Address
+
+Z Location Address
+Legacy Circuit Id
+
+ABCD/123456//ZYO
+Hard Down - Duration of maintenance window
+123 Main, Anytown, CA. USA
+123 1st, Othertown, CA. USA
+
+
+
+
+Please contact the Zayo Maintenance Team with any questions regarding this =
+maintenance event. Please reference the Maintenance Ticket number when call=
+ing.
+
+
+Maintenance Team Contacts:=20
+
+
+
+
+Zayo=A0Global Change Management Team/=C9quipe de Gestion du Changement Glob=
+al=A0Zayo
+
+Zayo | Our Fiber Fuels Global Innovation
+
+Toll free/No=A0sans=A0frais:=A01.866.236.2824
+
+United Kingdom Toll Free/No=A0sans
+frais Royaume-Uni:=A00800.169.1646
+
+Email/Courriel:=A0mr@zayo.com=A0
+
+Website/Site Web:=A0https://www.zayo.com
+
+Purpose=A0|=A0Network Map=A0|=A0Escalation List=A0|=A0LinkedIn=A0|=A0Twitte=
+r=A0|=A0Tranzact=A0
+
+=A0
+
+This communication is the property of Zayo and may contain confidential or =
+privileged information. If you have received this communication in error, p=
+lease promptly notify the sender by reply e-mail and destroy all copies of =
+the communication and any attachments.
+
+=A0
+------=_Part_14358_1498340646.1666133134471
+Content-Type: text/html; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+<html><b>
+Zayo Maintenance Notification=20
+
+<br><br>This email serves as official notification that Zayo and/or one of =
+its providers will be performing maintenance on its network as described be=
+low. This maintenance may affect services you have with us.
+</b>
+
+<br><br><b>Maintenance Ticket #: </b> TTN-0001234567
+
+<br><br><b>Urgency: </b> Emergency
+
+<br><br><b>Date Notice Sent: </b> 18-Oct-2022
+
+<br><br><b>Customer: </b> NSSI - Waves and Fiber
+
+<!-- <br><br><b>Maintenance Window: </b> 19:00 - 01:00 Central -->
+
+<br><br><b>Maintenance Window </b><br><br><b>1<sup>st</sup> Activity Date <=
+/b><br>18-Oct-2022 19:00 to 19-Oct-2022 01:00 ( Central )=20
+<br> 19-Oct-2022 00:00 to 19-Oct-2022 06:00 ( GMT )=20
+
+<br><br><b>Location of Maintenance: </b> NE
+
+<br><br><b>Reason for Maintenance: </b> Zayo will implement Emergency maint=
+enance to restore network stability and prevent an unplanned outage
+
+<br><br><b>Expected Impact: </b> Service Affecting Activity:  Any Maintenan=
+ce Activity directly impacting the service(s) of customers. Service(s) are =
+expected to go down as a result of these activities.
+
+<br><br><b>Circuit(s) Affected: </b><br>
+<table border=3D3D"1"><tr>
+<tr>
+<th>Circuit Id</th>
+<th>Expected Impact</th>
+<th>A Location Address</th>
+
+<th>Z Location Address</th>
+<th>Legacy Circuit Id</th>
+</tr>
+<tr>
+<td>ABCD/123456//ZYO</td>
+<td>Hard Down - Duration of maintenance window</td>
+<td>123 Main, Anytown, CA. USA</td>
+<td>567 1st, Somewhere, CA. USA</td>
+<td></td>
+</tr>
+</table>
+
+
+<br><br>Please contact the Zayo Maintenance Team with any questions regardi=
+ng this maintenance event. Please reference the Maintenance Ticket number w=
+hen calling.
+
+<br><br><b>Maintenance Team Contacts: </b><br><br>
+<div class=3DWordSection1>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white'><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#595959'>Zay</span></b><b><span style=3D'font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#FF8000'>o</span></b><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#595959'>&nbsp;Global Change Management Team/<span class=3DSpellE><i>=
+<span
+style=3D'background-image:initial;background-position:initial;background-re=
+peat:
+initial'>=C9quipe</i></span><i> de <span class=3DSpellE>Gestion</span> du <=
+span
+class=3DSpellE>Changement</span> Global&nbsp;Zay</span></span></b><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#FF=C98000'>o</span></b></i><span style=3D'font-family:"Arial",sans-seri=
+f;
+color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'white-space:pre-wrap'><b><span style=3D'font-family:"Tr=
+ebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#F79646'>Zayo | Our Fiber Fuels Global Inn=
+ovation</span></span></b><span style=3D'font-family:"Arial",sans-serif;
+color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'>Toll free/<i>N<sup>o</sup>&nbsp;s=
+ans&nbsp;<span
+class=3DSpellE>frais</span>:</i>&nbsp;</span><span style=3D'font-size:11.0p=
+t;
+font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:blue=
+'>1.866.236.2824</span><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'>United Kingdom Toll Free/<i>N<sup=
+>o</sup>&nbsp;sans
+<span class=3DSpellE>frais</span> <span class=3DSpellE>Royaume-Uni</span>:<=
+/i>&nbsp;</span><span
+style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;mso-bidi-fo=
+nt-family:
+Arial;color:blue'>0800.169.1646</span><span style=3D'font-size:11.0pt;font-=
+family:
+"Arial",sans-serif;color:#222222'><o:p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#222222;mso-ansi-language:FR'>Email/<i>Cou=
+rriel:</i>&nbsp;</span><u><span
+lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:blue;mso-ansi-language:FR'><a
+href=3D"mailto:releases@zayo.com" target=3D"_blank">mr@zayo.com</a></span><=
+/u><span
+lang=3DFR style=3D'font-size:11.0pt;font-family:"Trebuchet MS",sans-serif;
+mso-bidi-font-family:Arial;color:#222222;mso-ansi-language:FR'>&nbsp;</span=
+><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span class=3DSpellE><span lang=3DFR-CA style=3D'font-size:11.0pt;font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222;mso-ansi=
+-language:
+FR-CA'>Website</span></span><span lang=3DFR style=3D'font-size:11.0pt;font-=
+family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222;mso-ansi=
+-language:
+FR'>/<i>Site Web:</i>&nbsp;<a href=3D"http://www.zayo.com/" target=3D"_blan=
+k">https://www.zayo.com</a></span><span
+style=3D'font-size:11.0pt;font-family:"Arial",sans-serif;color:#222222'><o:=
+p></o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-fam=
+ily:
+Arial;color:#222222'><a href=3D"http://www.zayo.com/company/about-zayo/"
+target=3D"_blank"><b><span style=3D'color:#ED7D31'>Purpose</span></b></a></=
+span><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;|&nbsp;</span><span style=3D'font-family:"Trebuchet MS=
+",sans-serif;
+mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"http://www.zayo.com/solutions/global-network/" target=3D"_blank"><b=
+><span
+style=3D'color:#ED7D31'>Network Map</span></b></a></span><strong><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;</span></strong><span style=3D'font-family:"Trebuchet =
+MS",sans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>|&nbsp;</span><span style=3D'font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://tranzact.zayo.com/#!/escalation-lists" target=3D"_blank"><b=
+><span
+style=3D'color:#ED7D31'>Escalation List</span></b></a></span><b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>&nbsp;</span></b><span style=3D'font-family:"Trebuchet MS",s=
+ans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>|&nbsp;</span><span style=3D'font=
+-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://www.linkedin.com/company/530962/" target=3D"_blank"><b><spa=
+n
+style=3D'color:#ED7D31'>LinkedIn</span></b></a></span><b><span style=3D'fon=
+t-family:
+"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;color:#ED7D31'>&nbsp;<=
+/span></b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>|&nbsp;</span><span style=3D'font-family:"Trebuchet MS",sans=
+-serif;
+mso-bidi-font-family:Arial;color:#222222'><a
+href=3D"https://twitter.com/zayogroup" target=3D"_blank"><b><span style=3D'=
+color:
+#ED7D31'>Twitter</span></b></a></span><b><span style=3D'font-family:"Trebuc=
+het MS",sans-serif;
+mso-bidi-font-family:Arial;color:#ED7D31'>&nbsp;</span></b><span
+style=3D'font-family:"Trebuchet MS",sans-serif;mso-bidi-font-family:Arial;
+color:#ED7D31'>|&nbsp;<span class=3DSpellE><a
+href=3D"https://tranzact.zayo.com/#!/login" target=3D"_blank"><b><span
+style=3D'color:#ED7D31'>Tranzact</span></b><span style=3D'color:#ED7D31'>&n=
+bsp;</span></a></span></span><span
+style=3D'font-family:"Arial",sans-serif;color:#222222'><o:p></o:p></span></=
+p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;background-im=
+age:
+initial;background-position:initial;background-repeat:initial;word-spacing:
+0px'><span style=3D'font-family:"Arial",sans-serif;color:#222222'><o:p>&nbs=
+p;</o:p></span></p>
+
+<p style=3D'margin:0in;margin-bottom:.0001pt;background:white;font-variant-=
+ligatures: normal;
+font-variant-caps: normal;orphans: 2;text-align:start;widows: 2;-webkit-tex=
+t-stroke-width: 0px;
+text-decoration-style: initial;text-decoration-color: initial;word-spacing:
+0px'><b><i><span style=3D'font-size:9.0pt;font-family:"Trebuchet MS",sans-s=
+erif;
+mso-bidi-font-family:Arial;color:#7F7F7F'><span style=3D'white-space:pre-wr=
+ap'>This communication is the property of Zayo and may contain confidential=
+ or privileged information. If you have received this communication in erro=
+r, please promptly notify the sender by reply e-mail and destroy all copies=
+ of the communication and any attachments.</span></span></i></b><span style=
+=3D'font-size:
+10.0pt;font-family:"Arial",sans-serif;color:#222222'><o:p></o:p></span></p>
+
+<p class=3DMsoNormal><o:p>&nbsp;</o:p></p>
+
+</div></html>
+------=_Part_14358_1498340646.1666133134471--
+
+------=_Part_14359_801717674.1666133134471--

--- a/tests/unit/data/zayo/zayo10_html_parser_result.json
+++ b/tests/unit/data/zayo/zayo10_html_parser_result.json
@@ -1,0 +1,17 @@
+[
+    {
+        "account": "Customer,inc",
+        "circuits": [
+            {
+                "circuit_id": "ABCD/123456//ZYO",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1666159200,
+        "maintenance_id": "TTN-0001234567",
+        "stamp": 1666051200,
+        "start": 1666137600,
+        "status": "CONFIRMED",
+        "summary": "Zayo will implement EÉmergency maintenance to restore network stability and prevent an unplanned outage"
+    }
+]

--- a/tests/unit/data/zayo/zayo10_result.json
+++ b/tests/unit/data/zayo/zayo10_result.json
@@ -1,0 +1,21 @@
+[
+    {
+        "account": "Customer,inc",
+        "circuits": [
+            {
+                "circuit_id": "ABCD/123456//ZYO",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1666159200,
+        "maintenance_id": "TTN-0001234567",
+        "organizer": "mr@zayo.com",
+        "provider": "zayo",
+        "sequence": 1,
+        "stamp": 1666051200,
+        "start": 1666137600,
+        "status": "CONFIRMED",
+        "summary": "Zayo will implement EÉmergency maintenance to restore network stability and prevent an unplanned outage",
+        "uid": "0"
+    }
+]


### PR DESCRIPTION
Related to [Zayo email fails parser on email signature](https://github.com/networktocode/circuit-maintenance-parser/issues/175)

changes made to circuit_maintenance_parser/provider.py

Adds chardet.detect method before decoding data_part.content 