### PR TITLE
Parser for Apple peering notifications

### DIFF
--- a/circuit_maintenance_parser/__init__.py
+++ b/circuit_maintenance_parser/__init__.py
@@ -6,6 +6,7 @@ from .output import Maintenance
 from .errors import NonexistentProviderError, ProviderError
 from .provider import (
     GenericProvider,
+    Apple,
     AquaComms,
     AWS,
     BSO,
@@ -31,6 +32,7 @@ from .provider import (
 
 SUPPORTED_PROVIDERS = (
     GenericProvider,
+    Apple,
     AquaComms,
     AWS,
     BSO,

--- a/circuit_maintenance_parser/parsers/apple.py
+++ b/circuit_maintenance_parser/parsers/apple.py
@@ -1,0 +1,58 @@
+import email
+import re
+
+from typing import Dict, List
+
+from circuit_maintenance_parser.output import Impact, Status
+from circuit_maintenance_parser.parser import EmailSubjectParser, Text, CircuitImpact
+
+class SubjectParserApple(EmailSubjectParser):
+    def parser_hook(self, raw: bytes):
+        message = email.message_from_string(self.bytes_to_string(raw))
+        return self.parse_subject(message['subject'])
+
+    def parse_subject(self, subject: str) -> List[Dict]:
+        return [{'summary': subject}]
+
+
+class TextParserApple(Text):
+    def parse_text(self, text: str) -> List[Dict]:
+        data = {
+            'circuits': self._circuits(text),
+            'maintenance_id': self._maintenance_id(text),
+            'start': self._start_time(text),
+            'end': self._end_time(text),
+            'status': Status.CONFIRMED, # Have yet to see anything but confirmation.
+            'organizer': 'peering-noc@group.apple.com',
+            'provider': 'apple',
+        }
+        return [data]
+
+    def _circuits(self, text):
+        pattern = r'Peer AS: (\d*)'
+        m = re.search(pattern, text)
+        return [CircuitImpact(
+            circuit_id=f'AS{m.group(1)}',
+            impact=Impact.NO_IMPACT)]
+
+    def _maintenance_id(self, text):
+        # Apple ticket numbers always starts with "CHG".
+        pattern = r'CHG(\d*)'
+        m = re.search(pattern, text)
+        return m.group(0)
+
+    def _get_time(self, pattern, text):
+        # Apple sends timestamps as RFC2822, misused
+        # email module to convert to datetime.
+        m = re.search(pattern, text)
+        rfc2822 = m.group(1)
+        time_tuple = email.utils.parsedate_tz(rfc2822)
+        return email.utils.mktime_tz(time_tuple)
+
+    def _start_time(self, text):
+        pattern = 'Start Time: ([a-zA-Z0-9 :]*)'
+        return self._get_time(pattern, text)
+
+    def _end_time(self, text):
+        pattern = 'End Time: ([a-zA-Z0-9 :]*)'
+        return self._get_time(pattern, text)

--- a/circuit_maintenance_parser/provider.py
+++ b/circuit_maintenance_parser/provider.py
@@ -17,6 +17,7 @@ from circuit_maintenance_parser.errors import ProcessorError, ProviderError
 from circuit_maintenance_parser.processor import CombinedProcessor, SimpleProcessor, GenericProcessor
 from circuit_maintenance_parser.constants import EMAIL_HEADER_SUBJECT
 
+from circuit_maintenance_parser.parsers.apple import SubjectParserApple, TextParserApple
 from circuit_maintenance_parser.parsers.aquacomms import HtmlParserAquaComms1, SubjectParserAquaComms1
 from circuit_maintenance_parser.parsers.aws import SubjectParserAWS1, TextParserAWS1
 from circuit_maintenance_parser.parsers.bso import HtmlParserBSO1
@@ -163,6 +164,14 @@ class GenericProvider(BaseModel):
 ####################
 # PROVIDERS        #
 ####################
+
+class Apple(GenericProvider):
+    """Apple provider custom class."""
+
+    _processors: List[GenericProcessor] = [
+        CombinedProcessor(data_parsers=[TextParserApple, SubjectParserApple]),
+    ]
+    _default_organizer = "peering-noc@group.apple.com"
 
 
 class AquaComms(GenericProvider):

--- a/tests/unit/data/apple/apple1.eml
+++ b/tests/unit/data/apple/apple1.eml
@@ -1,0 +1,49 @@
+Date-warning: Date header was inserted by rn-mailsvcp-relay-lapp01.rno.apple.com
+Date: Mon, 01 May 2023 10:38:11 -0700 (PDT)
+Message-id: <0RTZ00SF5QBN8K50@rn-mailsvcp-relay-lapp01.rno.apple.com>
+Received: from prz3-cstools-hyp001.corp.apple.com
+ (prz3-cstools-hyp001.corp.apple.com [10.35.7.133])
+	by csmail.corp.apple.com (Postfix) with ESMTP id 1E23115EDE4;	Mon,
+ 1 May 2023 17:38:11 +0000 (UTC)
+Content-type: multipart/mixed; boundary="===============1255676001481217459=="
+MIME-version: 1.0
+From: noreply@apple.com
+Subject: Apple (AS714) Net Maintenance Notice for AS12345 in Chicago
+To: recipients not specified: ;
+
+--===============1255676001481217459==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+Apple (AS714) Network Maintenance Notification
+Reference Internal Ticket: CHG000123456
+Message sent to: noc@example.org
+
+Details:
+Start Time: 2 May 2023 14:00 UTC
+End Time: 16 May 2023 23:59 UTC
+
+Peering Details:
+Apple AS: 714
+Peer AS: 12345
+
+
+Apple IP: ['10.0.0.1', '2000:0000:0000:0000:0000:0000:0000:0001']
+Peer IP: ['10.0.0.2', '2000:0000:0000:0000:0000:0000:0000:0002']
+
+There is no change required on your end as we will gracefully drain the traffic prior to maintenance.
+
+When the maintenance is completed, Apple will automatically re-route traffic back.
+For reference, our current max prefix setting recommendation is: IPv4 = 10000 and IPv6 = 1000.
+Questions about this event can be sent to peering-noc@group.apple.com.
+
+Thank you for peering with Apple!
+
+Regards,
+
+Apple Peering NOC (AS714)
+peering-noc@group.apple.com
+as714.peeringdb.com
+
+--===============1255676001481217459==--

--- a/tests/unit/data/apple/apple1_result.json
+++ b/tests/unit/data/apple/apple1_result.json
@@ -1,0 +1,17 @@
+[
+    {
+        "circuits": [
+            {
+                "circuit_id": "AS12345",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1684281540,
+        "maintenance_id": "CHG000123456",
+        "start": 1683036000,
+        "status": "CONFIRMED",
+        "summary": "Apple (AS714) Net Maintenance Notice for AS12345 in Chicago",
+        "organizer": "peering-noc@group.apple.com",
+        "provider": "apple"
+    }
+]

--- a/tests/unit/data/apple/apple1_text_parser_result.json
+++ b/tests/unit/data/apple/apple1_text_parser_result.json
@@ -1,0 +1,16 @@
+[
+    {
+        "circuits": [
+            {
+                "circuit_id": "AS12345",
+                "impact": "NO-IMPACT"
+            }
+        ],
+        "end": 1684281540,
+        "maintenance_id": "CHG000123456",
+        "start": 1683036000,
+        "status": "CONFIRMED",
+        "organizer": "peering-noc@group.apple.com",
+        "provider": "apple"
+    }
+]

--- a/tests/unit/data/apple/apple2_subject_parser_result.json
+++ b/tests/unit/data/apple/apple2_subject_parser_result.json
@@ -1,0 +1,5 @@
+[
+    {
+        "summary": "Apple (AS714) Net Maintenance Notice for AS12345 in Chicago"
+    }
+]

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -13,6 +13,7 @@ from circuit_maintenance_parser.constants import EMAIL_HEADER_DATE, EMAIL_HEADER
 from circuit_maintenance_parser.provider import (
     Equinix,
     GenericProvider,
+    Apple,
     AquaComms,
     Arelion,
     AWS,
@@ -52,6 +53,16 @@ GENERIC_ICAL_RESULT_PATH = Path(dir_path, "data", "ical", "ical1_result.json")
             ],
             [
                 GENERIC_ICAL_RESULT_PATH,
+            ],
+        ),
+        # Apple
+        (
+            Apple,
+            [
+                ("email", Path(dir_path, "data", "apple", "apple1.eml")),
+            ],
+            [
+                Path(dir_path, "data", "apple", "apple1_result.json"),
             ],
         ),
         # AquaComms

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -7,6 +7,7 @@ import pytest
 
 from circuit_maintenance_parser.errors import ParserError
 from circuit_maintenance_parser.parser import ICal, EmailDateParser
+from circuit_maintenance_parser.parsers.apple import SubjectParserApple, TextParserApple
 from circuit_maintenance_parser.parsers.aquacomms import HtmlParserAquaComms1, SubjectParserAquaComms1
 from circuit_maintenance_parser.parsers.aws import SubjectParserAWS1, TextParserAWS1
 from circuit_maintenance_parser.parsers.bso import HtmlParserBSO1
@@ -67,6 +68,17 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
             ICal,
             Path(dir_path, "data", "ical", "ical6"),
             Path(dir_path, "data", "ical", "ical6_result.json"),
+        ),
+        # Apple
+        (
+            TextParserApple,
+            Path(dir_path, "data", "apple", "apple1.eml"),
+            Path(dir_path, "data", "apple", "apple1_text_parser_result.json"),
+        ),
+        (
+            SubjectParserApple,
+            Path(dir_path, "data", "apple", "apple1.eml"),
+            Path(dir_path, "data", "apple", "apple2_subject_parser_result.json"),
         ),
         # AquaComms
         (


### PR DESCRIPTION
Parser for Apple peering notification emails. We haven't yet seen anything that can be classified as other than "CONFIRMED"

The EmailSubjectParser behaves slightly different than one would expect based on the naming, in that it just get the entire email text, without line break. I would expect that it would receive ONLY the subject line, but that doesn't seem to be the case. Am I using it wrong perhaps?