### PR TITLE
Add missing Arelion entry to SUPPORTED_PROVIDERS

### DIFF
--- a/circuit_maintenance_parser/__init__.py
+++ b/circuit_maintenance_parser/__init__.py
@@ -7,6 +7,7 @@ from .errors import NonexistentProviderError, ProviderError
 from .provider import (
     GenericProvider,
     AquaComms,
+    Arelion,
     AWS,
     BSO,
     Cogent,
@@ -32,6 +33,7 @@ from .provider import (
 SUPPORTED_PROVIDERS = (
     GenericProvider,
     AquaComms,
+    Arelion,
     AWS,
     BSO,
     Cogent,


### PR DESCRIPTION
Longer term it would be nice to replace this omission-prone hard-coded list and instead do something like automatically pulling in all non-abstract subclasses of `GenericProvider`.