### PR TITLE
Improve Equinix parsing

### DIFF
--- a/circuit_maintenance_parser/parsers/equinix.py
+++ b/circuit_maintenance_parser/parsers/equinix.py
@@ -81,10 +81,7 @@ class HtmlParserEquinix(Html):
             # all circuits in the notification share the same impact
             if "IMPACT:" in b_elem:
                 impact_line = b_elem.next_sibling
-                if impact_line.next_sibling is None:
-                    impact_sibling_line = ""
-                else:
-                    impact_sibling_line = impact_line.next_sibling
+                impact_sibling_line = impact_line.next_sibling or ""
 
                 if "No impact to your service" in impact_line:
                     impact = Impact.NO_IMPACT

--- a/circuit_maintenance_parser/parsers/equinix.py
+++ b/circuit_maintenance_parser/parsers/equinix.py
@@ -64,7 +64,7 @@ class HtmlParserEquinix(Html):
                 raw_year_span = b_elem.text.strip().split()
                 start_year = raw_year_span[1].split("-")[-1]
                 end_year = raw_year_span[-1].split("-")[-1]
-            if "UTC:" in b_elem.text:
+            if start_year != 0 and "UTC:" in b_elem.text:
                 raw_time = b_elem.next_sibling
                 # for non english equinix notifications
                 # english section is usually at the bottom

--- a/circuit_maintenance_parser/parsers/equinix.py
+++ b/circuit_maintenance_parser/parsers/equinix.py
@@ -65,7 +65,6 @@ class HtmlParserEquinix(Html):
                 start_year = raw_year_span[1].split("-")[-1]
                 end_year = raw_year_span[-1].split("-")[-1]
             if "UTC:" in b_elem.text:
-                print("UTC found")
                 raw_time = b_elem.next_sibling
                 # for non english equinix notifications
                 # english section is usually at the bottom

--- a/circuit_maintenance_parser/parsers/equinix.py
+++ b/circuit_maintenance_parser/parsers/equinix.py
@@ -81,7 +81,7 @@ class HtmlParserEquinix(Html):
             # all circuits in the notification share the same impact
             if "IMPACT:" in b_elem:
                 impact_line = b_elem.next_sibling
-                impact_sibling_line = impact_line.next_sibling or ""
+                impact_sibling_line = (impact_line.next_sibling and impact_line.next_sibling.text) or ""
 
                 if "No impact to your service" in impact_line:
                     impact = Impact.NO_IMPACT

--- a/tests/unit/data/equinix/equinix6.eml
+++ b/tests/unit/data/equinix/equinix6.eml
@@ -1,0 +1,333 @@
+Delivered-To: foobar@example.com
+Date: Tue, 19 Dec 2023 13:54:45 -0800 (PST)
+From: Equinix Network Maintenance <no-reply@equinix.com>
+Reply-To: <no-reply@equinix.com>
+Message-ID: <xxx@xxx.service-now.com>
+Subject: CANCELLED - Remedial 3rd Party Dark Fiber OTDR testing between SV2 and SV8 - SV Metro Area Network Maintenance - 19-DEC-2023 [CHG0031000]
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_Part_123455_12375292.1234567"
+Precedence: bulk
+Auto-Submitted: auto-generated
+X-ServiceNow-Generated: true
+
+------=_Part_123455_12375292.1234567
+Content-Type: multipart/alternative; boundary="----=_Part_123456_54321.1234567"
+
+------=_Part_123456_54321.1234567
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+
+
+
+
+
+
+
+=C2=A0=C2=A0=C2=A0
+=C2=A0Dear Equinix Customers,=C2=A0
+=C2=A0
+The notification indicating maintenance on the systems below has been cance=
+lled. Any follow up or new system maintenance requests will follow our stan=
+dard notification protocol.
+=C2=A0=C2=A0=C2=A0
+ **************************************************************************=
+***
+From: Equinix Network Maintenance <no-reply@equinix.com>
+Sent: 2023-12-18 23:23:55
+Subject: Remedial 3rd Party Dark Fiber OTDR testing between SV2 and SV8 - S=
+V Metro Area Network Maintenance - 19-DEC-2023 [CHG0031000]
+=C2=A0=C2=A0=C2=A0
+=C2=A0Dear Equinix Customers,=C2=A0
+=C2=A0
+DATE: 19-DEC-2023 - 19-DEC-2023
+
+SPAN: 19-DEC-2023 - 19-DEC-2023
+
+LOCAL: TUESDAY, 19 DEC 14:00 - TUESDAY, 19 DEC 18:00
+UTC: TUESDAY, 19 DEC 22:00 - WEDNESDAY, 20 DEC 02:00
+
+IBX(s): SV2, SV8
+=C2=A0
+DESCRIPTION: Please be advised that one of our dark fiber providers will be=
+ performing a planned maintenance activity.
+
+EXPECTED SERVICE IMPACT:=20
+1. Unprotected Metro Connect (MC) circuits or Metro Remote ports will exper=
+ience service interruption.
+2. Protected Metro Connect circuits will experience multiple switching hits=
+ as traffic switches to protection path.
+3. One of your Dual Diverse Metro Connect circuits will experience port dow=
+ntime of up to 60 Minutes while Redundant circuits will not be affected.
+4. Equinix Fabric Metro Remote Port will experience service interruption.
+5. Network Edge circuits will experience service interruption.
+
+EXPECTED DURATION:=20
+1.Up to 60 minutes  for Unprotected MC
+2.Up to 15 minutes  for one of your Dual Diverse MC
+3.Up to 15 minutes for Equinix Fabric Metro Remote ports
+4.Up to 15 minutes  for Network Edge circuits=C2=A0
+=C2=A0
+PRODUCTS: Metro Connect=C2=A0
+=C2=A0
+IMPACT: Loss of redundancy to your service
+=C2=A0
+RECOMMENDED ACTION: Please be advised that one of our dark fiber providers =
+will be performing a planned maintenance activity.
+
+EXPECTED SERVICE IMPACT:=20
+1. Unprotected Metro Connect (MC) circuits or Metro Remote ports will exper=
+ience service interruption.
+2. Protected Metro Connect circuits will experience multiple switching hits=
+ as traffic switches to protection path.
+3. One of your Dual Diverse Metro Connect circuits will experience port dow=
+ntime of up to 60 Minutes while Redundant circuits will not be affected.
+4. Equinix Fabric Metro Remote Port will experience service interruption.
+5. Network Edge circuits will experience service interruption.
+
+EXPECTED DURATION:=20
+1.Up to 60 minutes  for Unprotected MC
+2.Up to 15 minutes  for one of your Dual Diverse MC
+3.Up to 15 minutes for Equinix Fabric Metro Remote ports
+4.Up to 15 minutes  for Network Edge circuits
+=C2=A0
+
+Impacted Assets
+
+Equinix Connect
+
+Account #ProductIBXService Serial #
+555555Equinix ConnectSV82345678
+
+=C2=A0
+We apologize for any inconvenience you may experience during this activity.=
+ Your cooperation and understanding are=C2=A0greatly appreciated.
+=C2=A0
+Please do not reply to this email address. If you have any questions or con=
+cerns regarding this notification, please log a network ticket via the Equi=
+nix Customer Portal or contact Global Service Desk and quote the ticket ref=
+erence.
+=C2=A0
+Equinix is available to answer questions, provide up-to-date status informa=
+tion or additional details regarding the maintenance. Please reference CHG0=
+031000.=C2=A0
+=C2=A0=C2=A0=C2=A0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Service Insight | Notification Preferences | Equinix Status Page | Support =
+Case=20
+
+ Glossary of terms | Equinix Customer Portal=20
+
+
+
+
+
+
+
+
+
+
+
+
+Equinix | Legal | Privacy  =20
+  =E2=80=AF =E2=80=AF =E2=80=AF  =20
+
+
+
+
+
+
+------=_Part_123456_54321.1234567
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+<html><head></head><body><table style=3D"border-collapse: collapse; margin:=
+ auto;border:1px solid #CFCFCF" border=3D"1" width=3D"700" cellspacing=3D"0=
+" cellpadding=3D"0" align=3D"center"><tbody><tr><td><table border=3D"0" sty=
+le=3D"width: 100%;">
+<tbody>
+<tr>
+<td height=3D"111" style=3D"text-align: center;"><img src=3D"http://info.eq=
+uinix.com/rs/equinixinc/images/banner-network-maintenance.gif" alt=3D"Meet =
+Equinix" width=3D"700" height=3D"115" border=3D"0"></td>
+</tr>
+</tbody>
+</table><table style=3D"border-collapse: collapse; margin: auto;" border=3D=
+"0" width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center"><tbo=
+dy><tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td width=3D"3=
+0">&nbsp;</td><td width=3D"642"><span style=3D"font-family: arial, helvetic=
+a, sans-serif; font-size: 10pt;">Dear Equinix Customers,&nbsp;</span><br><s=
+pan style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&=
+nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; f=
+ont-size: 10pt;">The notification indicating maintenance on the systems bel=
+ow has been cancelled. Any follow up or new system maintenance requests wil=
+l follow our standard notification protocol.</span></td></tr><tr style=3D"h=
+eight: 15.4px;"><td style=3D"height: 15.4px;">&nbsp;</td><td style=3D"heigh=
+t: 15.4px;">&nbsp;</td><td style=3D"height: 15.4px;">&nbsp;</td></tr></tbod=
+y></table><table style=3D"margin: auto; word-break: break-word; border-coll=
+apse: collapse; font-family: arial, helvetica, sans-serif; font-size: 10pt;=
+" width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center" bgcolo=
+r=3D"#FFFFFF"><tbody><tr><td width=3D"30">&nbsp;</td><td>******************=
+***********************************************************<br>From: Equini=
+x Network Maintenance &lt;no-reply@equinix.com&gt;<br>Sent: 2023-12-18 23:2=
+3:55<br>Subject: Remedial 3rd Party Dark Fiber OTDR testing between SV2 and=
+ SV8 - SV Metro Area Network Maintenance - 19-DEC-2023 [CHG0031000]</td></t=
+r></tbody></table><table style=3D"border-collapse: collapse; margin: auto; =
+height: 327.85px;" border=3D"0" width=3D"700" cellspacing=3D"0" cellpadding=
+=3D"0" align=3D"center"><tbody><tr style=3D"height: 15.4px;"><td style=3D"h=
+eight: 15.4px; width: 29.7px;">&nbsp;</td><td style=3D"height: 15.4px; widt=
+h: 637.375px;">&nbsp;</td><td style=3D"height: 15.4px; width: 29.725px;">&n=
+bsp;</td></tr><tr style=3D"height: 297.05px;"><td style=3D"height: 297.05px=
+; width: 29.7px;" width=3D"30">&nbsp;</td><td style=3D"height: 297.05px; wi=
+dth: 637.375px;" width=3D"642"><span style=3D"font-family: arial, helvetica=
+, sans-serif; font-size: 10pt;">Dear Equinix Customers,&nbsp;</span><br><sp=
+an style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&n=
+bsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; fo=
+nt-size: 10pt;"><strong>DATE:</strong> 19-DEC-2023 - 19-DEC-2023</span><br>=
+<span style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;"=
+><br><b>SPAN: 19-DEC-2023 - 19-DEC-2023</b><br><br><b>LOCAL: </b>TUESDAY, 1=
+9 DEC 14:00 - TUESDAY, 19 DEC 18:00<br><b>UTC: </b>TUESDAY, 19 DEC 22:00 - =
+WEDNESDAY, 20 DEC 02:00<br></span><br><span style=3D"font-family: arial, he=
+lvetica, sans-serif; font-size: 10pt;"><b>IBX(s): </b>SV2, SV8</span><br><s=
+pan style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&=
+nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; f=
+ont-size: 10pt;"><strong>DESCRIPTION:</strong> Please be advised that one o=
+f our dark fiber providers will be performing a planned maintenance activit=
+y.
+<br>
+<br>EXPECTED SERVICE IMPACT:=20
+<br>1. Unprotected Metro Connect (MC) circuits or Metro Remote ports will e=
+xperience service interruption.
+<br>2. Protected Metro Connect circuits will experience multiple switching =
+hits as traffic switches to protection path.
+<br>3. One of your Dual Diverse Metro Connect circuits will experience port=
+ downtime of up to 60 Minutes while Redundant circuits will not be affected=
+.
+<br>4. Equinix Fabric Metro Remote Port will experience service interruptio=
+n.
+<br>5. Network Edge circuits will experience service interruption.
+<br>
+<br>EXPECTED DURATION:=20
+<br>1.Up to 60 minutes  for Unprotected MC
+<br>2.Up to 15 minutes  for one of your Dual Diverse MC
+<br>3.Up to 15 minutes for Equinix Fabric Metro Remote ports
+<br>4.Up to 15 minutes  for Network Edge circuits&nbsp;</span><br><span sty=
+le=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</=
+span><br><span style=3D"font-family: arial, helvetica, sans-serif; font-siz=
+e: 10pt;"><strong>PRODUCTS:</strong> Metro Connect&nbsp;</span><br><span st=
+yle=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;<=
+/span><br><span style=3D"font-family: arial, helvetica, sans-serif; font-si=
+ze: 10pt;"><strong>IMPACT:</strong> Loss of redundancy to your service</spa=
+n><br><span style=3D"font-family: arial, helvetica, sans-serif; font-size: =
+10pt;">&nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-=
+serif; font-size: 10pt;"><strong>RECOMMENDED ACTION:</strong> Please be adv=
+ised that one of our dark fiber providers will be performing a planned main=
+tenance activity.
+<br>
+<br>EXPECTED SERVICE IMPACT:=20
+<br>1. Unprotected Metro Connect (MC) circuits or Metro Remote ports will e=
+xperience service interruption.
+<br>2. Protected Metro Connect circuits will experience multiple switching =
+hits as traffic switches to protection path.
+<br>3. One of your Dual Diverse Metro Connect circuits will experience port=
+ downtime of up to 60 Minutes while Redundant circuits will not be affected=
+.
+<br>4. Equinix Fabric Metro Remote Port will experience service interruptio=
+n.
+<br>5. Network Edge circuits will experience service interruption.
+<br>
+<br>EXPECTED DURATION:=20
+<br>1.Up to 60 minutes  for Unprotected MC
+<br>2.Up to 15 minutes  for one of your Dual Diverse MC
+<br>3.Up to 15 minutes for Equinix Fabric Metro Remote ports
+<br>4.Up to 15 minutes  for Network Edge circuits</span><br><span style=3D"=
+font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</span><=
+br><span style=3D"font-family: arial, helvetica, sans-serif; font-size: 10p=
+t;"><br><table style=3D"border-collapse: collapse;height:40px;" border=3D"0=
+" cellspacing=3D"0" cellpadding=3D"0"><tbody><tr><td><span style=3D"text-de=
+coration: underline;"><strong>Impacted Assets</strong></span></td></tr></tb=
+ody></table><br><div style=3D"text-decoration:underline;"><b>Equinix Connec=
+t</b></div><br><table style=3D"border-collapse: collapse; width: 99%;" bord=
+er=3D"1"><tbody><tr><th style=3D"width: 25%;">Account #</th><th style=3D"wi=
+dth: 25%;">Product</th><th style=3D"width: 25%;">IBX</th><th style=3D"width=
+: 25%;">Service Serial #</th></tr><tr><td style=3D"text-align: center;">555=
+555</td><td style=3D"text-align: center;">Equinix Connect</td><td style=3D"=
+text-align: center;">SV8</td><td style=3D"text-align: center;">2345678</td=
+></tr></tbody></table></span><br><span style=3D"font-family: arial, helveti=
+ca, sans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-fami=
+ly: arial, helvetica, sans-serif; font-size: 10pt;">We apologize for any in=
+convenience you may experience during this activity. Your cooperation and u=
+nderstanding are&nbsp;greatly appreciated.</span><br><span style=3D"font-fa=
+mily: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</span><br><spa=
+n style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">Ple=
+ase do not reply to this email address. If you have any questions or concer=
+ns regarding this notification, please log a network ticket via the Equinix=
+ Customer Portal or contact Global Service Desk and quote the ticket refere=
+nce.</span><br><span style=3D"font-family: arial, helvetica, sans-serif; fo=
+nt-size: 10pt;">&nbsp;</span><br><span style=3D"font-family: arial, helveti=
+ca, sans-serif; font-size: 10pt;">Equinix is available to answer questions,=
+ provide up-to-date status information or additional details regarding the =
+maintenance. Please reference CHG0031000.</span></td><td style=3D"height: 2=
+97.05px; width: 29.725px;" width=3D"30">&nbsp;</td></tr><tr style=3D"height=
+: 15.4px;"><td style=3D"height: 15.4px; width: 29.7px;">&nbsp;</td><td styl=
+e=3D"height: 15.4px; width: 637.375px;">&nbsp;</td><td style=3D"height: 15.=
+4px; width: 29.725px;">&nbsp;</td></tr></tbody></table><table width=3D"700"=
+ cellspacing=3D"0" cellpadding=3D"0" align=3D"center">
+<tbody>
+<tr>
+<td height=3D"20"><img src=3D"http://na-g.marketo.com/rs/equinixinc/images/=
+Event_Offering-seperator.jpg" width=3D"700" height=3D"20" style=3D"display:=
+ block; margin-left: auto; margin-right: auto;"></td>
+</tr>
+</tbody>
+</table>
+<table width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center">
+<tbody>
+<tr>
+<td>
+<p style=3D"text-align: center;"></p>
+<p style=3D"text-align: center; font-family: Arial, Helvetica, sans-serif; =
+color: #00a3e0;"><span style=3D"font-size: 10pt; color: #707073;"><a href=
+=3D"https://customerportal.equinix.com/cid/" target=3D"_blank" style=3D"col=
+or: #00a3e0;" rel=3D"noopener">Service Insight </a>| <a href=3D"https://cus=
+tomerportal.equinix.com/ecp/user/notifications" target=3D"_blank" rel=3D"no=
+opener" style=3D"color: #00a3e0;">Notification Preferences</a> | <a href=3D=
+"https://status.equinix.com" target=3D"_blank" rel=3D"noopener" style=3D"co=
+lor: #00a3e0;">Equinix Status Page</a> | <a href=3D"https://customerportal.=
+equinix.com/ecp/casemanagement" target=3D"_blank" rel=3D"noopener" style=3D=
+"color: #00a3e0;">Support Case</a>&nbsp;</span></p>
+<p style=3D"text-align: center; font-family: Arial, Helvetica, sans-serif; =
+color: #707073;"><span style=3D"font-size: 10pt;">&nbsp;<a href=3D"https://=
+www.equinix.com/welcome-guide/glossary" target=3D"_blank" rel=3D"noopener" =
+style=3D"color: #00a3e0;">Glossary of terms</a> | <a href=3D"https://custom=
+erportal.equinix.com" target=3D"_blank" rel=3D"noopener" style=3D"color: #0=
+0a3e0;">Equinix Customer Portal</a>&nbsp;</span></p>
+<p style=3D"text-align: center;"></p>
+</td>
+</tr>
+</tbody>
+</table>
+<table width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center" s=
+tyle=3D"height: 22.3958px;">
+<tbody>
+<tr style=3D"height: 22.3958px;">
+<td width=3D"10px;" td=3D""></td>
+<td width=3D"10px;"></td>
+</tr>
+</tbody>
+</table></td></tr></tbody></table></body></html>
+------=_Part_123456_54321.1234567--
+------=_Part_123455_12375292.1234567--

--- a/tests/unit/data/equinix/equinix6_result.json
+++ b/tests/unit/data/equinix/equinix6_result.json
@@ -1,0 +1,13 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "2345678",
+                "impact": "REDUCED-REDUNDANCY"
+            }
+        ],
+        "end": 1703037600,
+        "start": 1703023200
+    }
+]

--- a/tests/unit/data/equinix/equinix6_result_combined.json
+++ b/tests/unit/data/equinix/equinix6_result_combined.json
@@ -1,0 +1,21 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "2345678",
+                "impact": "REDUCED-REDUNDANCY"
+            }
+        ],
+        "end": 1703037600,
+        "maintenance_id": "CHG0031000",
+        "organizer": "servicedesk@equinix.com",
+        "provider": "equinix",
+        "sequence": 1,
+        "stamp": 1703022885,
+        "start": 1703023200,
+        "status": "CANCELLED",
+        "summary": "CANCELLED - Remedial 3rd Party Dark Fiber OTDR testing between SV2 and SV8 - SV Metro Area Network Maintenance - 19-DEC-2023 [CHG0031000]",
+        "uid": "0"
+    }
+]

--- a/tests/unit/data/equinix/equinix7.eml
+++ b/tests/unit/data/equinix/equinix7.eml
@@ -1,0 +1,266 @@
+Date: Thu, 21 Dec 2023 04:16:05 -0800 (PST)
+From: Equinix Network Maintenance <no-reply@equinix.com>
+Reply-To: <no-reply@equinix.com>
+Subject: Scheduled Software Upgrade - AM6, DB2, HE6, ZW1 Network Maintenance - (SERVICE IMPACTING) - 10-JAN-2024 [CHG0031000]
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_Part_111111_2222222.1234567898"
+X-ServiceNow-Generated: true
+
+------=_Part_111111_2222222.1234567898
+Content-Type: multipart/alternative; boundary="----=_Part_111112_17421832.1234567898"
+
+------=_Part_111112_17421832.1234567898
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+
+
+
+
+
+
+
+=C2=A0=C2=A0=C2=A0
+=C2=A0Dear Equinix Customers,=C2=A0
+=C2=A0
+DATE: 10-JAN-2024 - 11-JAN-2024
+
+SPAN: 10-JAN-2024 - 11-JAN-2024
+
+UTC: WEDNESDAY, 10 JAN 22:00 - THURSDAY, 11 JAN 06:00
+
+(Time Conversion Guide)
+=C2=A0
+LOCATION: AM6, DB2, HE6, ZW1=C2=A0
+=C2=A0
+DESCRIPTION: Please be advised that Equinix engineers will be performing a =
+planned software upgrade.=20
+
+For customers without redundancy configured ports and services a downtime i=
+s expected.
+Customers with redundant configured services will only experience a loss of=
+ redundancy.
+
+This work will impact network ports and virtual services listed in this not=
+ification.
+
+The expected duration would be:=20
+up to 120 minutes in the maintenance window (between 20 to 120 minutes).=C2=
+=A0
+=C2=A0
+OUTAGE DURATION: 2 Hours
+=C2=A0
+PRODUCTS: Equinix Connect, Equinix Internet Access, Equinix Fabric, Metro C=
+onnect=C2=A0
+=C2=A0
+IMPACT: There will be service interruptions
+=C2=A0
+RECOMMENDED ACTION: The Equinix platform provides redundancy options. To mi=
+tigate the impact of a maintenance event, we recommend customers to setup r=
+edundant connections according to best practices.
+
+No action is required from customers with redundancy.
+=C2=A0
+
+Impacted Assets
+
+Equinix Connect
+
+Account #ProductIBXService Serial #
+555555Equinix ConnectDB2EC1234.1
+
+=C2=A0
+We apologize for any inconvenience you may experience during this activity.=
+ Your cooperation and understanding are=C2=A0greatly appreciated.
+=C2=A0
+Please do not reply to this email address. If you have any questions or con=
+cerns regarding this notification, please log a network ticket via the Equi=
+nix Customer Portal or contact Global Service Desk and quote the ticket ref=
+erence.
+=C2=A0
+Equinix is available to answer questions, provide up-to-date status informa=
+tion or additional details regarding the maintenance. Please reference CHG0=
+031000.=C2=A0
+=C2=A0=C2=A0=C2=A0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Service Insight | Notification Preferences | Equinix Status Page | Support =
+Case=20
+
+ Glossary of terms | Equinix Customer Portal=20
+
+
+
+
+
+
+
+
+
+
+
+
+Equinix | Legal | Privacy  =20
+  =E2=80=AF =E2=80=AF =E2=80=AF  =20
+
+
+
+
+
+
+------=_Part_111112_17421832.1234567898
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+<html><head></head><body><table style=3D"border-collapse: collapse; margin:=
+ auto;border:1px solid #CFCFCF" border=3D"1" width=3D"700" cellspacing=3D"0=
+" cellpadding=3D"0" align=3D"center"><tbody><tr><td><table border=3D"0" sty=
+le=3D"width: 100%;">
+<tbody>
+<tr>
+<td height=3D"111" style=3D"text-align: center;"><img src=3D"http://info.eq=
+uinix.com/rs/equinixinc/images/banner-network-maintenance.gif" alt=3D"Meet =
+Equinix" width=3D"700" height=3D"115" border=3D"0"></td>
+</tr>
+</tbody>
+</table><table style=3D"border-collapse: collapse; margin: auto; height: 32=
+7.85px;" border=3D"0" width=3D"700" cellspacing=3D"0" cellpadding=3D"0" ali=
+gn=3D"center"><tbody><tr style=3D"height: 15.4px;"><td style=3D"height: 15.=
+4px; width: 29.6991px;">&nbsp;</td><td style=3D"height: 15.4px; width: 637.=
+581px;">&nbsp;</td><td style=3D"height: 15.4px; width: 29.7454px;">&nbsp;</=
+td></tr><tr style=3D"height: 297.05px;"><td style=3D"height: 297.05px; widt=
+h: 29.6991px;" width=3D"30">&nbsp;</td><td style=3D"height: 297.05px; width=
+: 637.581px;" width=3D"642"><span style=3D"font-family: arial, helvetica, s=
+ans-serif; font-size: 10pt;">Dear Equinix Customers,&nbsp;</span><br><span =
+style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp=
+;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; font-=
+size: 10pt;"><strong>DATE:</strong> 10-JAN-2024 - 11-JAN-2024</span><br><sp=
+an style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;"><b=
+r><b>SPAN: 10-JAN-2024 - 11-JAN-2024</b><br><br><b>UTC: </b>WEDNESDAY, 10 J=
+AN 22:00 - THURSDAY, 11 JAN 06:00<br></span><br><span style=3D"font-family:=
+ arial, helvetica, sans-serif; font-size: 10pt;"><a href=3D"https://www.tim=
+eanddate.com/worldclock/converter-classic.html" rel=3D"nofollow">(Time Conv=
+ersion Guide)</a></span><br><span style=3D"font-family: arial, helvetica, s=
+ans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-family: a=
+rial, helvetica, sans-serif; font-size: 10pt;"><strong>LOCATION:</strong> A=
+M6, DB2, HE6, ZW1&nbsp;</span><br><span style=3D"font-family: arial, helvet=
+ica, sans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-fam=
+ily: arial, helvetica, sans-serif; font-size: 10pt;"><strong>DESCRIPTION:</=
+strong> Please be advised that Equinix engineers will be performing a plann=
+ed software upgrade.=20
+<br>
+<br>For customers without redundancy configured ports and services a downti=
+me is expected.
+<br>Customers with redundant configured services will only experience a los=
+s of redundancy.
+<br>
+<br>This work will impact network ports and virtual services listed in this=
+ notification.
+<br>
+<br>The expected duration would be:=20
+<br>up to 120 minutes in the maintenance window (between 20 to 120 minutes)=
+.&nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif;=
+ font-size: 10pt;">&nbsp;<br><strong>OUTAGE DURATION:</strong> 2 Hours<br>&=
+nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; f=
+ont-size: 10pt;"><strong>PRODUCTS:</strong> Equinix Connect, Equinix Intern=
+et Access, Equinix Fabric, Metro Connect&nbsp;</span><br><span style=3D"fon=
+t-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</span><br>=
+<span style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;"=
+><strong>IMPACT:</strong> There will be service interruptions</span><br><sp=
+an style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&n=
+bsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; fo=
+nt-size: 10pt;"><strong>RECOMMENDED ACTION:</strong> The Equinix platform p=
+rovides redundancy options. To mitigate the impact of a maintenance event, =
+we recommend customers to setup redundant connections according to best pra=
+ctices.
+<br>
+<br>No action is required from customers with redundancy.</span><br><span s=
+tyle=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;=
+</span><br><span style=3D"font-family: arial, helvetica, sans-serif; font-s=
+ize: 10pt;"><br><table style=3D"border-collapse: collapse;height:40px;" bor=
+der=3D"0" cellspacing=3D"0" cellpadding=3D"0"><tbody><tr><td><span style=3D=
+"text-decoration: underline;"><strong>Impacted Assets</strong></span></td><=
+/tr></tbody></table><br><div style=3D"text-decoration:underline;"><b>Equini=
+x Connect</b></div><br><table style=3D"border-collapse: collapse; width: 99=
+%;" border=3D"1"><tbody><tr><th style=3D"width: 25%;">Account #</th><th sty=
+le=3D"width: 25%;">Product</th><th style=3D"width: 25%;">IBX</th><th style=
+=3D"width: 25%;">Service Serial #</th></tr><tr><td style=3D"text-align: cen=
+ter;">555555</td><td style=3D"text-align: center;">Equinix Connect</td><td =
+style=3D"text-align: center;">DB2</td><td style=3D"text-align: center;">EC1=
+234.1</td></tr></tbody></table></span><br><span style=3D"font-family: arial=
+, helvetica, sans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"=
+font-family: arial, helvetica, sans-serif; font-size: 10pt;">We apologize f=
+or any inconvenience you may experience during this activity. Your cooperat=
+ion and understanding are&nbsp;greatly appreciated.</span><br><span style=
+=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</sp=
+an><br><span style=3D"font-family: arial, helvetica, sans-serif; font-size:=
+ 10pt;">Please do not reply to this email address. If you have any question=
+s or concerns regarding this notification, please log a network ticket via =
+the Equinix Customer Portal or contact Global Service Desk and quote the ti=
+cket reference.</span><br><span style=3D"font-family: arial, helvetica, san=
+s-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-family: ari=
+al, helvetica, sans-serif; font-size: 10pt;">Equinix is available to answer=
+ questions, provide up-to-date status information or additional details reg=
+arding the maintenance. Please reference CHG0031000.</span></td><td style=
+=3D"height: 297.05px; width: 29.7454px;" width=3D"30">&nbsp;</td></tr><tr s=
+tyle=3D"height: 15.4px;"><td style=3D"height: 15.4px; width: 29.6991px;">&n=
+bsp;</td><td style=3D"height: 15.4px; width: 637.581px;">&nbsp;</td><td sty=
+le=3D"height: 15.4px; width: 29.7454px;">&nbsp;</td></tr></tbody></table><t=
+able width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center">
+<tbody>
+<tr>
+<td height=3D"20"><img src=3D"http://na-g.marketo.com/rs/equinixinc/images/=
+Event_Offering-seperator.jpg" width=3D"700" height=3D"20" style=3D"display:=
+ block; margin-left: auto; margin-right: auto;"></td>
+</tr>
+</tbody>
+</table>
+<table width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center">
+<tbody>
+<tr>
+<td>
+<p style=3D"text-align: center;"></p>
+<p style=3D"text-align: center; font-family: Arial, Helvetica, sans-serif; =
+color: #00a3e0;"><span style=3D"font-size: 10pt; color: #707073;"><a href=
+=3D"https://customerportal.equinix.com/cid/" target=3D"_blank" style=3D"col=
+or: #00a3e0;" rel=3D"noopener">Service Insight </a>| <a href=3D"https://cus=
+tomerportal.equinix.com/ecp/user/notifications" target=3D"_blank" rel=3D"no=
+opener" style=3D"color: #00a3e0;">Notification Preferences</a> | <a href=3D=
+"https://status.equinix.com" target=3D"_blank" rel=3D"noopener" style=3D"co=
+lor: #00a3e0;">Equinix Status Page</a> | <a href=3D"https://customerportal.=
+equinix.com/ecp/casemanagement" target=3D"_blank" rel=3D"noopener" style=3D=
+"color: #00a3e0;">Support Case</a>&nbsp;</span></p>
+<p style=3D"text-align: center; font-family: Arial, Helvetica, sans-serif; =
+color: #707073;"><span style=3D"font-size: 10pt;">&nbsp;<a href=3D"https://=
+www.equinix.com/welcome-guide/glossary" target=3D"_blank" rel=3D"noopener" =
+style=3D"color: #00a3e0;">Glossary of terms</a> | <a href=3D"https://custom=
+erportal.equinix.com" target=3D"_blank" rel=3D"noopener" style=3D"color: #0=
+0a3e0;">Equinix Customer Portal</a>&nbsp;</span></p>
+<p style=3D"text-align: center;"></p>
+</td>
+</tr>
+</tbody>
+</table>
+<table width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center" s=
+tyle=3D"height: 22.3958px;">
+<tbody>
+<tr style=3D"height: 22.3958px;">
+<td width=3D"10px;" td=3D""></td>
+<td width=3D"10px;"></td>
+</tr>
+</tbody>
+</table></td></tr></tbody></table></body></html>
+------=_Part_111112_17421832.1234567898--
+------=_Part_111111_2222222.1234567898--

--- a/tests/unit/data/equinix/equinix7_result.json
+++ b/tests/unit/data/equinix/equinix7_result.json
@@ -1,0 +1,13 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "EC1234.1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1704952800,
+        "start": 1704924000
+    }
+]

--- a/tests/unit/data/equinix/equinix7_result_combined.json
+++ b/tests/unit/data/equinix/equinix7_result_combined.json
@@ -1,0 +1,21 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "EC1234.1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1704952800,
+        "maintenance_id": "CHG0031000",
+        "organizer": "servicedesk@equinix.com",
+        "provider": "equinix",
+        "sequence": 1,
+        "stamp": 1703160965,
+        "start": 1704924000,
+        "status": "CONFIRMED",
+        "summary": "Scheduled Software Upgrade - AM6, DB2, HE6, ZW1 Network Maintenance - (SERVICE IMPACTING) - 10-JAN-2024 [CHG0031000]",
+        "uid": "0"
+    }
+]

--- a/tests/unit/data/equinix/equinix8.eml
+++ b/tests/unit/data/equinix/equinix8.eml
@@ -1,0 +1,266 @@
+Date: Thu, 21 Dec 2023 04:16:05 -0800 (PST)
+From: Equinix Network Maintenance <no-reply@equinix.com>
+Reply-To: <no-reply@equinix.com>
+Subject: Scheduled Software Upgrade - AM6, DB2, HE6, ZW1 Network Maintenance - (SERVICE IMPACTING) - 10-JAN-2024 [CHG0031000]
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_Part_111111_2222222.1234567898"
+X-ServiceNow-Generated: true
+
+------=_Part_111111_2222222.1234567898
+Content-Type: multipart/alternative; boundary="----=_Part_111112_17421832.1234567898"
+
+------=_Part_111112_17421832.1234567898
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+
+
+
+
+
+
+
+=C2=A0=C2=A0=C2=A0
+=C2=A0Dear Equinix Customers,=C2=A0
+=C2=A0
+DATE: 10-JAN-2024 - 11-JAN-2024
+
+SPAN: 10-JAN-2024 - 11-JAN-2024
+
+UTC: WEDNESDAY, 10 JAN 22:00 - THURSDAY, 11 JAN 06:00
+
+(Time Conversion Guide)
+=C2=A0
+LOCATION: AM6, DB2, HE6, ZW1=C2=A0
+=C2=A0
+DESCRIPTION: Please be advised that Equinix engineers will be performing a =
+planned software upgrade.=20
+
+For customers without redundancy configured ports and services a downtime i=
+s expected.
+Customers with redundant configured services will only experience a loss of=
+ redundancy.
+
+This work will impact network ports and virtual services listed in this not=
+ification.
+
+The expected duration would be:=20
+up to 120 minutes in the maintenance window (between 20 to 120 minutes).=C2=
+=A0
+=C2=A0
+OUTAGE DURATION: 2 Hours
+=C2=A0
+PRODUCTS: Equinix Connect, Equinix Internet Access, Equinix Fabric, Metro C=
+onnect=C2=A0
+=C2=A0
+IMPACT: There will be service interruptions
+=C2=A0
+RECOMMENDED ACTION: The Equinix platform provides redundancy options. To mi=
+tigate the impact of a maintenance event, we recommend customers to setup r=
+edundant connections according to best practices.
+
+No action is required from customers with redundancy.
+=C2=A0
+
+Impacted Assets
+
+Equinix Connect
+
+Account #ProductIBXService Serial #
+555555Equinix ConnectDB2EC1234.1
+
+=C2=A0
+We apologize for any inconvenience you may experience during this activity.=
+ Your cooperation and understanding are=C2=A0greatly appreciated.
+=C2=A0
+Please do not reply to this email address. If you have any questions or con=
+cerns regarding this notification, please log a network ticket via the Equi=
+nix Customer Portal or contact Global Service Desk and quote the ticket ref=
+erence.
+=C2=A0
+Equinix is available to answer questions, provide up-to-date status informa=
+tion or additional details regarding the maintenance. Please reference CHG0=
+031000.=C2=A0
+=C2=A0=C2=A0=C2=A0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Service Insight | Notification Preferences | Equinix Status Page | Support =
+Case=20
+
+ Glossary of terms | Equinix Customer Portal=20
+
+
+
+
+
+
+
+
+
+
+
+
+Equinix | Legal | Privacy  =20
+  =E2=80=AF =E2=80=AF =E2=80=AF  =20
+
+
+
+
+
+
+------=_Part_111112_17421832.1234567898
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset=UTF-8
+
+<html><head></head><body><table style=3D"border-collapse: collapse; margin:=
+ auto;border:1px solid #CFCFCF" border=3D"1" width=3D"700" cellspacing=3D"0=
+" cellpadding=3D"0" align=3D"center"><tbody><tr><td><table border=3D"0" sty=
+le=3D"width: 100%;">
+<tbody>
+<tr>
+<td height=3D"111" style=3D"text-align: center;"><img src=3D"http://info.eq=
+uinix.com/rs/equinixinc/images/banner-network-maintenance.gif" alt=3D"Meet =
+Equinix" width=3D"700" height=3D"115" border=3D"0"></td>
+</tr>
+</tbody>
+</table><table style=3D"border-collapse: collapse; margin: auto; height: 32=
+7.85px;" border=3D"0" width=3D"700" cellspacing=3D"0" cellpadding=3D"0" ali=
+gn=3D"center"><tbody><tr style=3D"height: 15.4px;"><td style=3D"height: 15.=
+4px; width: 29.6991px;">&nbsp;</td><td style=3D"height: 15.4px; width: 637.=
+581px;">&nbsp;</td><td style=3D"height: 15.4px; width: 29.7454px;">&nbsp;</=
+td></tr><tr style=3D"height: 297.05px;"><td style=3D"height: 297.05px; widt=
+h: 29.6991px;" width=3D"30">&nbsp;</td><td style=3D"height: 297.05px; width=
+: 637.581px;" width=3D"642"><span style=3D"font-family: arial, helvetica, s=
+ans-serif; font-size: 10pt;">Dear Equinix Customers,&nbsp;</span><br><span =
+style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp=
+;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; font-=
+size: 10pt;"><strong>DATE:</strong> 10-JAN-2024 - 11-JAN-2024</span><br><sp=
+an style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;"><b=
+r><b>SPAN: 10-JAN-2024 - 11-JAN-2024</b><br><br><b>UTC: </b>WEDNESDAY, 10 J=
+AN 22:00 - THURSDAY, 11 JAN 06:00<br></span><br><span style=3D"font-family:=
+ arial, helvetica, sans-serif; font-size: 10pt;"><a href=3D"https://www.tim=
+eanddate.com/worldclock/converter-classic.html" rel=3D"nofollow">(Time Conv=
+ersion Guide)</a></span><br><span style=3D"font-family: arial, helvetica, s=
+ans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-family: a=
+rial, helvetica, sans-serif; font-size: 10pt;"><strong>LOCATION:</strong> A=
+M6, DB2, HE6, ZW1&nbsp;</span><br><span style=3D"font-family: arial, helvet=
+ica, sans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-fam=
+ily: arial, helvetica, sans-serif; font-size: 10pt;"><strong>DESCRIPTION:</=
+strong> Please be advised that Equinix engineers will be performing a plann=
+ed software upgrade.=20
+<br>
+<br>For customers without redundancy configured ports and services a downti=
+me is expected.
+<br>Customers with redundant configured services will only experience a los=
+s of redundancy.
+<br>
+<br>This work will impact network ports and virtual services listed in this=
+ notification.
+<br>
+<br>The expected duration would be:=20
+<br>up to 120 minutes in the maintenance window (between 20 to 120 minutes)=
+.&nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif;=
+ font-size: 10pt;">&nbsp;<br><strong>OUTAGE DURATION:</strong> 2 Hours<br>&=
+nbsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; f=
+ont-size: 10pt;"><strong>PRODUCTS:</strong> Equinix Connect, Equinix Intern=
+et Access, Equinix Fabric, Metro Connect&nbsp;</span><br><span style=3D"fon=
+t-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</span><br>=
+<b>IMPACT:</b>=09<font style=3D"background-color: yellow;">There will be se=
+rvice interruptions</font><br><sp=
+an style=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&n=
+bsp;</span><br><span style=3D"font-family: arial, helvetica, sans-serif; fo=
+nt-size: 10pt;"><strong>RECOMMENDED ACTION:</strong> The Equinix platform p=
+rovides redundancy options. To mitigate the impact of a maintenance event, =
+we recommend customers to setup redundant connections according to best pra=
+ctices.
+<br>
+<br>No action is required from customers with redundancy.</span><br><span s=
+tyle=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;=
+</span><br><span style=3D"font-family: arial, helvetica, sans-serif; font-s=
+ize: 10pt;"><br><table style=3D"border-collapse: collapse;height:40px;" bor=
+der=3D"0" cellspacing=3D"0" cellpadding=3D"0"><tbody><tr><td><span style=3D=
+"text-decoration: underline;"><strong>Impacted Assets</strong></span></td><=
+/tr></tbody></table><br><div style=3D"text-decoration:underline;"><b>Equini=
+x Connect</b></div><br><table style=3D"border-collapse: collapse; width: 99=
+%;" border=3D"1"><tbody><tr><th style=3D"width: 25%;">Account #</th><th sty=
+le=3D"width: 25%;">Product</th><th style=3D"width: 25%;">IBX</th><th style=
+=3D"width: 25%;">Service Serial #</th></tr><tr><td style=3D"text-align: cen=
+ter;">555555</td><td style=3D"text-align: center;">Equinix Connect</td><td =
+style=3D"text-align: center;">DB2</td><td style=3D"text-align: center;">EC1=
+234.1</td></tr></tbody></table></span><br><span style=3D"font-family: arial=
+, helvetica, sans-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"=
+font-family: arial, helvetica, sans-serif; font-size: 10pt;">We apologize f=
+or any inconvenience you may experience during this activity. Your cooperat=
+ion and understanding are&nbsp;greatly appreciated.</span><br><span style=
+=3D"font-family: arial, helvetica, sans-serif; font-size: 10pt;">&nbsp;</sp=
+an><br><span style=3D"font-family: arial, helvetica, sans-serif; font-size:=
+ 10pt;">Please do not reply to this email address. If you have any question=
+s or concerns regarding this notification, please log a network ticket via =
+the Equinix Customer Portal or contact Global Service Desk and quote the ti=
+cket reference.</span><br><span style=3D"font-family: arial, helvetica, san=
+s-serif; font-size: 10pt;">&nbsp;</span><br><span style=3D"font-family: ari=
+al, helvetica, sans-serif; font-size: 10pt;">Equinix is available to answer=
+ questions, provide up-to-date status information or additional details reg=
+arding the maintenance. Please reference CHG0031000.</span></td><td style=
+=3D"height: 297.05px; width: 29.7454px;" width=3D"30">&nbsp;</td></tr><tr s=
+tyle=3D"height: 15.4px;"><td style=3D"height: 15.4px; width: 29.6991px;">&n=
+bsp;</td><td style=3D"height: 15.4px; width: 637.581px;">&nbsp;</td><td sty=
+le=3D"height: 15.4px; width: 29.7454px;">&nbsp;</td></tr></tbody></table><t=
+able width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center">
+<tbody>
+<tr>
+<td height=3D"20"><img src=3D"http://na-g.marketo.com/rs/equinixinc/images/=
+Event_Offering-seperator.jpg" width=3D"700" height=3D"20" style=3D"display:=
+ block; margin-left: auto; margin-right: auto;"></td>
+</tr>
+</tbody>
+</table>
+<table width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center">
+<tbody>
+<tr>
+<td>
+<p style=3D"text-align: center;"></p>
+<p style=3D"text-align: center; font-family: Arial, Helvetica, sans-serif; =
+color: #00a3e0;"><span style=3D"font-size: 10pt; color: #707073;"><a href=
+=3D"https://customerportal.equinix.com/cid/" target=3D"_blank" style=3D"col=
+or: #00a3e0;" rel=3D"noopener">Service Insight </a>| <a href=3D"https://cus=
+tomerportal.equinix.com/ecp/user/notifications" target=3D"_blank" rel=3D"no=
+opener" style=3D"color: #00a3e0;">Notification Preferences</a> | <a href=3D=
+"https://status.equinix.com" target=3D"_blank" rel=3D"noopener" style=3D"co=
+lor: #00a3e0;">Equinix Status Page</a> | <a href=3D"https://customerportal.=
+equinix.com/ecp/casemanagement" target=3D"_blank" rel=3D"noopener" style=3D=
+"color: #00a3e0;">Support Case</a>&nbsp;</span></p>
+<p style=3D"text-align: center; font-family: Arial, Helvetica, sans-serif; =
+color: #707073;"><span style=3D"font-size: 10pt;">&nbsp;<a href=3D"https://=
+www.equinix.com/welcome-guide/glossary" target=3D"_blank" rel=3D"noopener" =
+style=3D"color: #00a3e0;">Glossary of terms</a> | <a href=3D"https://custom=
+erportal.equinix.com" target=3D"_blank" rel=3D"noopener" style=3D"color: #0=
+0a3e0;">Equinix Customer Portal</a>&nbsp;</span></p>
+<p style=3D"text-align: center;"></p>
+</td>
+</tr>
+</tbody>
+</table>
+<table width=3D"700" cellspacing=3D"0" cellpadding=3D"0" align=3D"center" s=
+tyle=3D"height: 22.3958px;">
+<tbody>
+<tr style=3D"height: 22.3958px;">
+<td width=3D"10px;" td=3D""></td>
+<td width=3D"10px;"></td>
+</tr>
+</tbody>
+</table></td></tr></tbody></table></body></html>
+------=_Part_111112_17421832.1234567898--
+------=_Part_111111_2222222.1234567898--

--- a/tests/unit/data/equinix/equinix8.json
+++ b/tests/unit/data/equinix/equinix8.json
@@ -1,0 +1,21 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "EC1234.1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1704952800,
+        "maintenance_id": "CHG0031000",
+        "organizer": "servicedesk@equinix.com",
+        "provider": "equinix",
+        "sequence": 1,
+        "stamp": 1703160965,
+        "start": 1704924000,
+        "status": "CONFIRMED",
+        "summary": "Scheduled Software Upgrade - AM6, DB2, HE6, ZW1 Network Maintenance - (SERVICE IMPACTING) - 10-JAN-2024 [CHG0031000]",
+        "uid": "0"
+    }
+]

--- a/tests/unit/data/equinix/equinix8_result.json
+++ b/tests/unit/data/equinix/equinix8_result.json
@@ -1,0 +1,13 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "EC1234.1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1704952800,
+        "start": 1704924000
+    }
+]

--- a/tests/unit/data/equinix/equinix8_result_combined.json
+++ b/tests/unit/data/equinix/equinix8_result_combined.json
@@ -1,0 +1,21 @@
+[   
+    {
+        "account": "555555",
+        "circuits": [
+            {
+                "circuit_id": "EC1234.1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1704952800,
+        "maintenance_id": "CHG0031000",
+        "organizer": "servicedesk@equinix.com",
+        "provider": "equinix",
+        "sequence": 1,
+        "stamp": 1703160965,
+        "start": 1704924000,
+        "status": "CONFIRMED",
+        "summary": "Scheduled Software Upgrade - AM6, DB2, HE6, ZW1 Network Maintenance - (SERVICE IMPACTING) - 10-JAN-2024 [CHG0031000]",
+        "uid": "0"
+    }
+]

--- a/tests/unit/data/equinix/equinix9.eml
+++ b/tests/unit/data/equinix/equinix9.eml
@@ -1,0 +1,326 @@
+Return-Path: <no-reply@equinix.com>
+Date: Tue, 7 Nov 2023 05:04:09 +0000 (UTC)
+From: Equinix Network Maintenance NO-REPLY <no-reply@equinix.com>
+Reply-To: Equinix Network Maintenance NO-REPLY <no-reply@equinix.com>
+To: "Equinix Network Maintenance.NL" <EquinixNetworkMaintenance.NL@eu.equinix.com>
+Subject: COMPLETED - Scheduled Software Upgrade-AM Metro Area Network Maintenance (SERVICE IMPACTING)-06-NOV-2023 [5-230281950000]
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="----=_Part_333333_222222222.111111111111111111"
+X-Priority: 1
+Organization: Equinix, Inc
+
+------=_Part_333333_222222222.111111111111111111
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+ Geachte Equinix Klant/Dear Equinix Customer,
+
+De hieronder vermelde onderhoudswerkzaamheden zijn inmiddels afgerond.
+
+The maintenance listed below has now been completed.
+
+ =20
+
+Geachte Equinix klant,
+
+DATUM:=09=0906-NOV-2023 - 07-NOV-2023
+
+TIJDSDUUR:=09=0906-NOV-2023 - 07-NOV-2023
+
+LOKALE TIJD:=09=09MAANDAG, 06 NOV 22:00 - DINSDAG, 07 NOV 06:00
+UTC:=09=09MAANDAG, 06 NOV 21:00 - DINSDAG, 07 NOV 05:00
+
+IBX(s): AM1,AM2
+
+BESCHRIJVING:=09
+Please be advised that Equinix engineers will perform a software upgrade on=
+ our Equinix Fabric routers.=20
+The Equinix platform provides redundancy options. To mitigate the impact of=
+ a maintenance event, we recommend customers to setup redundant connections=
+ according to best practices.
+
+EXPECTED SERVICE IMPACT:=20
+For customers without redundancy configured ports and services a downtime i=
+s expected. Customers with redundant configured services will only experien=
+ce a loss of redundancy.
+This work will impact network ports and virtual services listed in the Tabl=
+e below.
+
+EXPECTED DURATION:=20
+Up to 60 minutes in the maintenance window (between 20 to 60 minutes)
+
+PRODUCTEN:EQUINIX CONNECT, EQUINIX FABRIC, EQUINIX INTERNET ACCESS, INTER M=
+ETRO CONNECT, METRO CONNECT
+
+IMPACT:=09Er zullen service onderbrekingen zijn.
+
+
+Equinix Connect =09 =09=09=09 =09=09=09 =09=09=09=09    Account # =09=09=09=
+=09    Product =09=09=09=09    IBX =09=09=09=09    Service Serial # =09=09=
+=09 =09=09=09=09 =09=09=09=09=09=09 333333 =09=09=09=09=09=09 Equinix Conne=
+ct =09=09=09=09=09=09 AM5 =09=09=09=09=09=09 44444.AM1 =09=09=09=09 =09=09=
+=09=09 =09=09=09=09=09=09 333333 =09=09=09=09=09=09 Equinix Connect =09=09=
+=09=09=09=09 AM5 =09=09=09=09=09=09 66666.AM1 =09=09=09=09 =09=09=09 =09
+
+
+
+Onze excuses voor het eventuele ongemak dat u kunt ervaren tijdens deze act=
+iviteit.  Uw medewerking en begrip worden zeer gewaardeerd.
+
+De Equinix SMC is beschikbaar om up-to-date informatie of extra gegevens te=
+ verschaffen. Mocht u vragen hebben over deze activiteit wilt u dan referer=
+en aan 5-230281950685.=20
+
+***************************************************************************=
+***********
+
+Dear Equinix Customer,
+
+DATE:=09=0906-NOV-2023 - 07-NOV-2023
+
+SPAN:=09=0906-NOV-2023 - 07-NOV-2023
+
+LOCAL:=09=09MONDAY, 06 NOV 22:00 - TUESDAY, 07 NOV 06:00
+UTC:=09=09MONDAY, 06 NOV 21:00 - TUESDAY, 07 NOV 05:00
+
+IBX(s): AM1,AM11,AM3,AM5,EN1
+
+
+DESCRIPTION:
+Please be advised that Equinix engineers will perform a software upgrade on=
+ our Equinix Fabric routers.=20
+The Equinix platform provides redundancy options. To mitigate the impact of=
+ a maintenance event, we recommend customers to setup redundant connections=
+ according to best practices.
+
+EXPECTED SERVICE IMPACT:=20
+For customers without redundancy configured ports and services a downtime i=
+s expected. Customers with redundant configured services will only experien=
+ce a loss of redundancy.
+This work will impact network ports and virtual services listed in the Tabl=
+e below.
+
+EXPECTED DURATION:=20
+Up to 60 minutes in the maintenance window (between 20 to 60 minutes)
+
+PRODUCTS:=09EQUINIX CONNECT, EQUINIX FABRIC, EQUINIX INTERNET ACCESS, INTER=
+ METRO CONNECT, METRO CONNECT
+
+IMPACT:=09There will be service interruptions.
+
+=09
+We apologize for any inconvenience you may experience during this activity.=
+  Your cooperation and understanding are greatly appreciated.
+
+The Equinix SMC is available to provide up-to-date status information or ad=
+ditional details, should you have any questions regarding the maintenance. =
+ Please reference 5-230281950000.=20
+
+
+Sincerely,=20
+Equinix SMC=20
+Contacts:
+Please do not reply to this email address. If you have any questions or con=
+cerns regarding this notification, please log a network ticket via the Equi=
+nix Customer Portal, or contact Global Service Desk and quote the the ticke=
+t reference [5-230281950000].=20
+To unsubscribe from notifications, please log in to the Equinix Customer Po=
+rtal  and change your preferences.
+
+------=_Part_333333_222222222.111111111111111111
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+<style type="text/css">
+<!--
+
+a:link {
+        color: #215CA1;
+}
+a:visited {
+        color: #215CA1;
+}
+a:hover {
+        color: #215CA1;
+}
+a:active {
+        color: #215CA1;
+}
+ul
+{
+padding: 0px;
+margin: 20px;
+}
+body {
+        margin-left: 10px;
+        margin-top: 10px;
+        margin-right: 10px;
+        margin-bottom: 10px;
+}
+-->
+</style>
+<title></title>
+</head>
+<body ><table width="100%" cellspacing="0" cellpadding="0" >
+<tr><td>
+<table width="750" align="center" cellpadding="0" cellspacing="0" bgcolor="#FFFFFF" ><tr ><td ><div align="center" ><img src="http://info.equinix.com/rs/equinixinc/images/banner-network-maintenance.gif" alt="Meet Equinix" width="100.14%" height="115" border="0" /></div></td></tr><tr ><td ><table width="100%" cellspacing="0" cellpadding="0" ><tr ><td height="0" >
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr ><td style="border-left:1px solid #cccccc; border-right:1px solid #cccccc; " ><table width="100%" cellspacing="0" cellpadding="0" ><tr>
+
+<td align="center" height="20" colspan="3"></td>
+</tr>
+<tr ><td width="30">&nbsp;</td>
+<td width="642" valign="top" style="border-bottom:1px solid #cccccc; " ><table width="100%" cellspacing="0" cellpadding="0" ><tr ><td valign="top" style="padding-bottom:20px; " ><table width="100%" cellspacing="0" cellpadding="0" >
+<p><span style="font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#555555; " >
+Geachte Equinix Klant/Dear Equinix Customer,<br />
+<br />
+De hieronder vermelde onderhoudswerkzaamheden zijn inmiddels afgerond.<br />
+<br />
+The maintenance listed below has now been completed.<br />
+<br />
+</p></span>
+<hr>
+<p><span style="font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#555555; " ><br />
+Geachte Equinix klant,<br />
+<br />
+<b>DATUM:</b>		06-NOV-2023 - 07-NOV-2023<br />
+<br />
+<b>TIJDSDUUR:		06-NOV-2023 - 07-NOV-2023</b><br />
+<br />
+<b>LOKALE TIJD:</b>		MAANDAG, 06 NOV 22:00 - DINSDAG, 07 NOV 06:00<br />
+<b>UTC:</b>		MAANDAG, 06 NOV 21:00 - DINSDAG, 07 NOV 05:00<br />
+<br />
+<b>IBX(s): </b>AM1,AM11,AM3,AM5,EN1<br />
+<br />
+<b>BESCHRIJVING:</b>	<br>Please be advised that Equinix engineers will perform a software upgrade on our Equinix Fabric routers. <br />
+The Equinix platform provides redundancy options. To mitigate the impact of a maintenance event, we recommend customers to setup redundant connections according to best practices.<br />
+<br />
+<b>EXPECTED SERVICE IMPACT: </b><br />
+For customers without redundancy configured ports and services a downtime is expected. Customers with redundant configured services will only experience a loss of redundancy.<br />
+This work will impact network ports and virtual services listed in the Table below.<br />
+<br />
+<b>EXPECTED DURATION: </b><br />
+Up to 60 minutes in the maintenance window (between 20 to 60 minutes)<br />
+<br />
+<b>PRODUCTEN:</b>EQUINIX CONNECT, EQUINIX FABRIC, EQUINIX INTERNET ACCESS, INTER METRO CONNECT, METRO CONNECT<br />
+<br />
+<b>IMPACT:</b>	<font style="background-color: yellow;">Er zullen service onderbrekingen zijn.</font><br />
+</p><br />
+<br/>
+    <b><u>Equinix Connect</u></b>
+	
+
+			<table style="font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#555555; width:100%;border:1px solid black;border-collapse:collapse;table-layout:fixed">
+			<tr>
+				    <th style="border:1px solid; width:25%">Account #</th>
+				    <th style="border:1px solid; width:25%">Product</th>
+				    <th style="border:1px solid; width:25%">IBX</th>
+				    <th style="border:1px solid; width:25%">Service Serial #</th>
+			</tr>
+				<tr>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">333333</td>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">Equinix Connect</td>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">AM5</td>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">44444.AM1</td>
+				</tr>
+				<tr>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">333333</td>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">Equinix Connect</td>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">AM5</td>
+						 <td align="center" style="border:1px solid;word-wrap: break-word;  width:25%">66666.AM1</td>
+				</tr>
+			</table>
+	<br/>
+<span style="font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#555555; " ><br />
+<p><span style="font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#555555; "><br />
+Onze excuses voor het eventuele ongemak dat u kunt ervaren tijdens deze activiteit.  Uw medewerking en begrip worden zeer gewaardeerd.<br />
+<br />
+De Equinix SMC is beschikbaar om up-to-date informatie of extra gegevens te verschaffen. Mocht u vragen hebben over deze activiteit wilt u dan refereren aan 5-230281950000. <br />
+<br />
+**************************************************************************************<br />
+<br />
+Dear Equinix Customer,<br />
+<br />
+<b>DATE:</b>		06-NOV-2023 - 07-NOV-2023<br />
+<br />
+<b>SPAN:		06-NOV-2023 - 07-NOV-2023</b><br />
+<br />
+<b>LOCAL:</b>		MONDAY, 06 NOV 22:00 - TUESDAY, 07 NOV 06:00<br />
+<b>UTC:</b>		MONDAY, 06 NOV 21:00 - TUESDAY, 07 NOV 05:00<br />
+<br />
+<b>IBX(s): </b>AM1,AM11,AM3,AM5,EN1<br />
+<br />
+<Int Desc><br />
+<b>DESCRIPTION:</b><br>Please be advised that Equinix engineers will perform a software upgrade on our Equinix Fabric routers. <br />
+The Equinix platform provides redundancy options. To mitigate the impact of a maintenance event, we recommend customers to setup redundant connections according to best practices.<br />
+<br />
+<b>EXPECTED SERVICE IMPACT: </b><br />
+For customers without redundancy configured ports and services a downtime is expected. Customers with redundant configured services will only experience a loss of redundancy.<br />
+This work will impact network ports and virtual services listed in the Table below.<br />
+<br />
+<b>EXPECTED DURATION: </b><br />
+Up to 60 minutes in the maintenance window (between 20 to 60 minutes)<br />
+<br />
+<b>PRODUCTS:</b>	EQUINIX CONNECT, EQUINIX FABRIC, EQUINIX INTERNET ACCESS, INTER METRO CONNECT, METRO CONNECT<br />
+<br />
+<b>IMPACT:</b>	<font style="background-color: yellow;">There will be service interruptions.</font><br />
+<br />	<br /> We apologize for any inconvenience you may experience during this activity.  Your cooperation and understanding are greatly appreciated.<br /> <br /> The Equinix SMC is available to provide up-to-date status information or additional details, should you have any questions regarding the maintenance.  Please reference 5-230281950000. <br />
+<br />
+<p>Sincerely, <br> Equinix SMC </p> <p><span style="font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000000; font-weight:bold; ">Contacts:</span></p> <p> Please do not reply to this email address. If you have any questions or concerns regarding this notification, please log a network ticket via the <a href="https://customerportal.equinix.com/">Equinix Customer Portal</a>, or contact <a href="http://www.equinix.com/contact-us/customer-support/">Global Service Desk</a> and quote the the ticket reference [5-230281950000]. </p><tr ><td height="35" valign="top" ><div style="font-family:Arial, Helvetica, sans-serif; font-size:12px; color:#555555; " ><br />
+<center>To unsubscribe from notifications, please log in to the <a href ="https://customerportal.equinix.com/user/notifications" target="_blank">Equinix Customer Portal </a> and change your preferences.</center><br />
+<pre><font face="arial"></font></pre></div>
+ </td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+</td>
+<td width="30">
+<p>&nbsp;</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr ><td style="border-left:1px solid #cccccc; border-right:1px solid #cccccc; border-bottom:1px solid #cccccc; " ><table width="700" cellpadding="0" cellspacing="0" ><tr ><td width="95" align="center"><a href="http://www.equinix.com"><img src="http://na-g.marketo.com/rs/equinixinc/images/Equinix-Logo_icon-white.gif" alt="Equinix" width="35" height="23" border="0" /></a></td>
+<td width="597" align="right" ><table border="0" align="right" cellpadding="0" cellspacing="0" ><tr ><td align="right" valign="middle" style="font-family:Arial, Helvetica, sans-serif; font-size:11px; color:#aaaaaa; " ><span style="font-family:Arial, Helvetica, sans-serif; font-size:14px; font-weight:bold; color:#555555; font-weight:bold;">How are we doing? Tell Equinix - We're Listening.</span>
+
+</td>
+<td width="10" height="64" align="center">&nbsp;</td>
+<td align="left" valign="middle" style="font-family:Arial, Helvetica, sans-serif; font-size:11px; color:#aaaaaa; " ><a href="#" target="_blank" style="border:0;"></a><a href="#" target="_blank"></a><a href="https://equinix.qualtrics.com/jfe/form/SV_5tZRNCGwOKna7A1"><img src="http://info.equinix.com/rs/equinixinc/images/FOOTERBUTTON-feedback-en.gif" width="132" height="34" border="0" /></a>
+</td>
+</tr>
+</table>
+</td>
+<td width="30" align="right">&nbsp;</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<table width="704" align="center" cellpadding="0" cellspacing="0">
+<tr>
+<td><img src="http://na-g.marketo.com/rs/equinixinc/images/Event_Offering-seperator.jpg" width="704" height="20" /></td>
+</tr>
+
+</table>
+</td>
+</tr>
+
+</table>
+</td>
+</tr>
+</table>
+</body>
+</html>
+------=_Part_333333_222222222.111111111111111111--

--- a/tests/unit/data/equinix/equinix9_result.json
+++ b/tests/unit/data/equinix/equinix9_result.json
@@ -1,0 +1,17 @@
+[   
+    {
+        "account": "333333",
+        "circuits": [
+            {
+                "circuit_id": "44444.AM1",
+                "impact": "OUTAGE"
+            },
+            {
+                "circuit_id": "66666.AM1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1699333200,
+        "start": 1699304400
+    }
+]

--- a/tests/unit/data/equinix/equinix9_result_combined.json
+++ b/tests/unit/data/equinix/equinix9_result_combined.json
@@ -1,0 +1,25 @@
+[   
+    {
+        "account": "333333",
+        "circuits": [
+            {
+                "circuit_id": "44444.AM1",
+                "impact": "OUTAGE"
+            },
+            {
+                "circuit_id": "66666.AM1",
+                "impact": "OUTAGE"
+            }
+        ],
+        "end": 1699333200,
+        "maintenance_id": "5-230281950000",
+        "organizer": "servicedesk@equinix.com",
+        "provider": "equinix",
+        "sequence": 1,
+        "stamp": 1699333449,
+        "start": 1699304400,
+        "status": "COMPLETED",
+        "summary": "COMPLETED - Scheduled Software Upgrade-AM Metro Area Network Maintenance (SERVICE IMPACTING)-06-NOV-2023 [5-230281950000]",
+        "uid": "0"
+    }
+]

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -294,6 +294,11 @@ GENERIC_ICAL_RESULT_PATH = Path(dir_path, "data", "ical", "ical1_result.json")
             [("email", Path(dir_path, "data", "equinix", "equinix8.eml"))],
             [Path(dir_path, "data", "equinix", "equinix8_result_combined.json")],
         ),
+        (
+            Equinix,
+            [("email", Path(dir_path, "data", "equinix", "equinix9.eml"))],
+            [Path(dir_path, "data", "equinix", "equinix9_result_combined.json")],
+        ),
         # EUNetworks
         (
             EUNetworks,

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -279,6 +279,16 @@ GENERIC_ICAL_RESULT_PATH = Path(dir_path, "data", "ical", "ical1_result.json")
             [("email", Path(dir_path, "data", "equinix", "equinix5.eml"))],
             [Path(dir_path, "data", "equinix", "equinix5_result_combined.json")],
         ),
+        (
+            Equinix,
+            [("email", Path(dir_path, "data", "equinix", "equinix6.eml"))],
+            [Path(dir_path, "data", "equinix", "equinix6_result_combined.json")],
+        ),
+        (
+            Equinix,
+            [("email", Path(dir_path, "data", "equinix", "equinix7.eml"))],
+            [Path(dir_path, "data", "equinix", "equinix7_result_combined.json")],
+        ),
         # EUNetworks
         (
             EUNetworks,

--- a/tests/unit/test_e2e.py
+++ b/tests/unit/test_e2e.py
@@ -289,6 +289,11 @@ GENERIC_ICAL_RESULT_PATH = Path(dir_path, "data", "ical", "ical1_result.json")
             [("email", Path(dir_path, "data", "equinix", "equinix7.eml"))],
             [Path(dir_path, "data", "equinix", "equinix7_result_combined.json")],
         ),
+        (
+            Equinix,
+            [("email", Path(dir_path, "data", "equinix", "equinix8.eml"))],
+            [Path(dir_path, "data", "equinix", "equinix8_result_combined.json")],
+        ),
         # EUNetworks
         (
             EUNetworks,

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -259,6 +259,11 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
             Path(dir_path, "data", "equinix", "equinix8.eml"),
             Path(dir_path, "data", "equinix", "equinix8_result.json"),
         ),
+        (
+            HtmlParserEquinix,
+            Path(dir_path, "data", "equinix", "equinix9.eml"),
+            Path(dir_path, "data", "equinix", "equinix9_result.json"),
+        ),
         # GTT
         (
             HtmlParserGTT1,

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -254,6 +254,11 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
             Path(dir_path, "data", "equinix", "equinix7.eml"),
             Path(dir_path, "data", "equinix", "equinix7_result.json"),
         ),
+        (
+            HtmlParserEquinix,
+            Path(dir_path, "data", "equinix", "equinix8.eml"),
+            Path(dir_path, "data", "equinix", "equinix8_result.json"),
+        ),
         # GTT
         (
             HtmlParserGTT1,

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -244,6 +244,16 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
             Path(dir_path, "data", "equinix", "equinix5.eml"),
             Path(dir_path, "data", "equinix", "equinix5_result.json"),
         ),
+        (
+            HtmlParserEquinix,
+            Path(dir_path, "data", "equinix", "equinix6.eml"),
+            Path(dir_path, "data", "equinix", "equinix6_result.json"),
+        ),
+        (
+            HtmlParserEquinix,
+            Path(dir_path, "data", "equinix", "equinix7.eml"),
+            Path(dir_path, "data", "equinix", "equinix7_result.json"),
+        ),
         # GTT
         (
             HtmlParserGTT1,


### PR DESCRIPTION
This makes five changes:

1. It now handles cancel messages.
2. Equinix sometimes uses `<strong>` instead of `<bold>`, so I updated the beautifulsoup calls to look for both (and changed` _parse_b()` to `_parse_bolded()` to be more accurate).
3. UTC: was never found in my sample messages in `b_elem`, but it was always in `b_elem.text`, so I updated that. Tests still pass and it parses the messages I am receiving from Equinix.
4. "There will be service interruptions" was found in `impact_line` in my messages, not i`mpact_line.next_sibling` (which was None and thus causing an exception).  I reworked it to do both checks, and also not crash if `impact_line` does not have a `next_sibling`.
5. I added tests for the new code, using messages I've received from Equinix as the source, with obfuscation applied.