### PR TITLE
Correct incorrect logic in validation code

### DIFF
--- a/circuit_maintenance_parser/output.py
+++ b/circuit_maintenance_parser/output.py
@@ -197,7 +197,7 @@ class Maintenance(BaseModel, extra="forbid"):
     def validate_empty_circuits(cls, value, values):
         """Validate non-cancel notifications have a populated circuit list."""
         values = values.data
-        if len(value) < 1 and str(values["status"]) in ("CANCELLED", "COMPLETED"):
+        if len(value) < 1 and str(values["status"]) not in ("Status.CANCELLED", "Status.COMPLETED"):
             raise ValueError("At least one circuit has to be included in the maintenance")
         return value
 


### PR DESCRIPTION
This fixes the issue reported by https://github.com/networktocode/circuit-maintenance-parser/pull/259#issuecomment-1965547758

While the test code validated that this was working, the bad logic worked because `str(values["status"])` would be prefaced by `Status.`.  So I corrected both the list and the logical operator.