### PR TITLE
Fix various exceptions under Pydantic 1.x

### DIFF
--- a/circuit_maintenance_parser/output.py
+++ b/circuit_maintenance_parser/output.py
@@ -204,7 +204,10 @@ class Maintenance(BaseModel, extra="forbid"):
     @classmethod
     def validate_empty_circuits(cls, value, values):
         """Validate non-cancel notifications have a populated circuit list."""
-        values = values.data
+        try:
+            values = values.data  # pydantic 2.x
+        except AttributeError:  # pydantic 1.x
+            pass
         if len(value) < 1 and values["status"] not in (Status.CANCELLED, Status.COMPLETED):
             raise ValueError("At least one circuit has to be included in the maintenance")
         return value
@@ -213,7 +216,10 @@ class Maintenance(BaseModel, extra="forbid"):
     @classmethod
     def validate_end_time(cls, end, values):
         """Validate that End time happens after Start time."""
-        values = values.data
+        try:
+            values = values.data  # pydantic 2.x
+        except AttributeError:  # pydantic 1.x
+            pass
         if "start" not in values:
             raise ValueError("Start time is a mandatory attribute.")
         start = values["start"]

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -46,7 +46,7 @@ class Parser(BaseModel):
             return cls._data_types.get_default()
         except AttributeError:
             # TODO: This exception handling is required for Pydantic 1.x compatibility. To be removed when the dependency is deprecated.
-            return cls._data_types
+            return cls()._data_types
 
     @classmethod
     def get_name(cls) -> str:

--- a/circuit_maintenance_parser/provider.py
+++ b/circuit_maintenance_parser/provider.py
@@ -155,7 +155,7 @@ class GenericProvider(BaseModel):
             return cls._default_organizer.get_default()  # type: ignore
         except AttributeError:
             # TODO: This exception handling is required for Pydantic 1.x compatibility. To be removed when the dependency is deprecated.
-            return cls._default_organizer
+            return cls()._default_organizer
 
     @classmethod
     def get_default_processors(cls) -> List[GenericProcessor]:
@@ -164,7 +164,7 @@ class GenericProvider(BaseModel):
             return cls._processors.get_default()  # type: ignore
         except AttributeError:
             # TODO: This exception handling is required for Pydantic 1.x compatibility. To be removed when the dependency is deprecated.
-            return cls._processors
+            return cls()._processors
 
     @classmethod
     def get_default_include_filters(cls) -> Dict[str, List[str]]:
@@ -173,7 +173,7 @@ class GenericProvider(BaseModel):
             return cls._include_filter.get_default()  # type: ignore
         except AttributeError:
             # TODO: This exception handling is required for Pydantic 1.x compatibility. To be removed when the dependency is deprecated.
-            return cls._include_filter
+            return cls()._include_filter
 
     @classmethod
     def get_default_exclude_filters(cls) -> Dict[str, List[str]]:
@@ -182,7 +182,7 @@ class GenericProvider(BaseModel):
             return cls._exclude_filter.get_default()  # type: ignore
         except AttributeError:
             # TODO: This exception handling is required for Pydantic 1.x compatibility. To be removed when the dependency is deprecated.
-            return cls._exclude_filter
+            return cls()._exclude_filter
 
     @classmethod
     def get_extended_data(cls):


### PR DESCRIPTION
Although v2.6.0 claims to be backwards-compatible with Pydantic 1.x, using it with `nautobot-circuit-maintenance` with Pydantic 1.x causes it to throw exceptions in several places. This PR fixes those.