### PR TITLE
Move epoch parser outside of LLM due to inconsistencies

### DIFF
--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -417,7 +417,7 @@ class LLM(Parser):
             return epoch_time
 
         except Exception as error_received:
-            logger.debug("Error parsing dates: %s", error_received)
+            logger.error("Error parsing dates: %s", error_received)
             raise ParserError from error_received
 
     def _get_start(self, generated_json: dict):

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -7,6 +7,7 @@ import datetime
 import quopri
 from typing import Dict, List
 from email.utils import parsedate_tz, mktime_tz
+from dateutil.parser import isoparse
 import hashlib
 
 import bs4  # type: ignore
@@ -297,15 +298,15 @@ class LLM(Parser):
     _data_types = PrivateAttr(["text/html", "html", "text/plain"])
 
     _llm_question = """Please, could you extract a JSON form without any other comment,
-    with the following JSON schema (timestamps in EPOCH and taking into account the GMT offset):
+    with the following JSON schema (start and end times are datetime objects and should be displayed in UTC):
     {
     "type": "object",
     "properties": {
         "start": {
-            "type": "int",
+            "type": "datetime",
         },
         "end": {
-            "type": "int",
+            "type": "datetime",
         },
         "account": {
             "type": "string",
@@ -408,6 +409,20 @@ class LLM(Parser):
 
         return circuits
 
+    def _convert_str_datetime_to_epoch(self, time_str):
+        try:
+            # Using isoparse for flexible ISO8601 parsing
+            time_dt = isoparse(time_str).astimezone(datetime.timezone.utc)
+            epoch_time = int(time_dt.timestamp())
+            return epoch_time
+
+        except Exception as e:
+            # Log the error message for debugging
+            print(f"Error parsing dates: {e}")
+            # Optionally, you might raise a custom exception or return None values
+            raise
+
+
     def _get_start(self, generated_json: dict):
         """Method to get the Start Time."""
         return generated_json[self.get_key_with_string(generated_json, "start")]
@@ -459,6 +474,10 @@ class LLM(Parser):
         generated_json = self.get_llm_response(content)
         if not generated_json:
             return []
+
+        if generated_json.get('start') and generated_json.get('end'):
+            generated_json['start'] = self._convert_str_datetime_to_epoch(generated_json['start'])
+            generated_json['end'] = self._convert_str_datetime_to_epoch(generated_json['end'])
 
         impact = self._get_impact(generated_json)
 

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -5,10 +5,10 @@ import base64
 import calendar
 import datetime
 import quopri
+import hashlib
 from typing import Dict, List
 from email.utils import parsedate_tz, mktime_tz
 from dateutil.parser import isoparse
-import hashlib
 
 import bs4  # type: ignore
 from bs4.element import ResultSet  # type: ignore
@@ -416,12 +416,11 @@ class LLM(Parser):
             epoch_time = int(time_dt.timestamp())
             return epoch_time
 
-        except Exception as e:
+        except Exception as error_received:
             # Log the error message for debugging
-            print(f"Error parsing dates: {e}")
+            print(f"Error parsing dates: {error_received}")
             # Optionally, you might raise a custom exception or return None values
             raise
-
 
     def _get_start(self, generated_json: dict):
         """Method to get the Start Time."""
@@ -475,9 +474,9 @@ class LLM(Parser):
         if not generated_json:
             return []
 
-        if generated_json.get('start') and generated_json.get('end'):
-            generated_json['start'] = self._convert_str_datetime_to_epoch(generated_json['start'])
-            generated_json['end'] = self._convert_str_datetime_to_epoch(generated_json['end'])
+        if generated_json.get("start") and generated_json.get("end"):
+            generated_json["start"] = self._convert_str_datetime_to_epoch(generated_json["start"])
+            generated_json["end"] = self._convert_str_datetime_to_epoch(generated_json["end"])
 
         impact = self._get_impact(generated_json)
 

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -417,7 +417,7 @@ class LLM(Parser):
             return epoch_time
 
         except Exception as error_received:
-            logger.debug(f"Error parsing dates: {error_received}")
+            logger.debug("Error parsing dates: %s", error_received)
             raise ParserError from error_received
 
     def _get_start(self, generated_json: dict):

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -417,10 +417,8 @@ class LLM(Parser):
             return epoch_time
 
         except Exception as error_received:
-            # Log the error message for debugging
-            print(f"Error parsing dates: {error_received}")
-            # Optionally, you might raise a custom exception or return None values
-            raise
+            logger.debug(f"Error parsing dates: {error_received}")
+            raise ParserError from error_received
 
     def _get_start(self, generated_json: dict):
         """Method to get the Start Time."""


### PR DESCRIPTION
Was testing out the LLM parser and realised that there were a lot of inconsistencies passing in the same email multiple times.

The LLM API has a lot of issues converting the date string into epoch time.

I've messed around with the API directly by asking it questions like "Please convert the following time <> into an epoch string" (I wanted to avoid using a full email as I thought there might have been some special characters in the middle of the strings).
It still couldn't do it consistently. I also did checks prior to the epoch being converted and can see that the LLM can extract the datetime str correctly every time... It just couldn't do the conversion.

I asked the same question directly to the ChatGPT application on my local PC and this worked flawlessly, so there must be some difference between the API and the app (And yes, I have made sure the model I was using was the same on both).

After some discussions with @chadell directly, I have pulled the epoch conversion from the llm_question and made sure we get a datetime string from the API (I've tested this part of the LLM and it can do it very consistently). I've then written a function to do the conversion from datetime string into an epoch time myself.

From my testing, this seems very consistent and accurate.