### PR TITLE
Add multi-windows for LLM

### DIFF
--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -521,30 +521,30 @@ class LLM(Parser):
 
         # Process backup windows
         for window in generated_json.get("backup_windows", []):
-                if "start" in window and "end" in window:
-                    backup_start = self._convert_str_datetime_to_epoch(window["start"])
-                    backup_end = self._convert_str_datetime_to_epoch(window["end"])
+            if "start" in window and "end" in window:
+                backup_start = self._convert_str_datetime_to_epoch(window["start"])
+                backup_end = self._convert_str_datetime_to_epoch(window["end"])
 
-                    backup_data = {
-                        "circuits": main_data["circuits"],  # Same circuits
-                        "start": backup_start,
-                        "end": backup_end,
-                        "summary": main_data["summary"],
-                        "status": main_data["status"],
-                        "account": main_data["account"],
-                    }
+                backup_data = {
+                    "circuits": main_data["circuits"],  # Same circuits
+                    "start": backup_start,
+                    "end": backup_end,
+                    "summary": main_data["summary"],
+                    "status": main_data["status"],
+                    "account": main_data["account"],
+                }
 
-                    # Generate a new maintenance ID for the backup window
-                    backup_data["maintenance_id"] = str(
-                        self._get_maintenance_id(
-                            generated_json,
-                            backup_start,
-                            backup_end,
-                            backup_data["circuits"],
-                        )
+                # Generate a new maintenance ID for the backup window
+                backup_data["maintenance_id"] = str(
+                    self._get_maintenance_id(
+                        generated_json,
+                        backup_start,
+                        backup_end,
+                        backup_data["circuits"],
                     )
+                )
 
-                    data_list.append(backup_data)
+                data_list.append(backup_data)
 
         return data_list  # Returning a list with main and backup windows
 

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -548,6 +548,7 @@ class LLM(Parser):
 
         return data_list  # Returning a list with main and backup windows
 
+
 class Xlsx(Parser):
     """Xlsx parser."""
 

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -520,8 +520,7 @@ class LLM(Parser):
         data_list.append(main_data)
 
         # Process backup windows
-        if "backup_windows" in generated_json:
-            for window in generated_json["backup_windows"]:
+        for window in generated_json.get("backup_windows", []):
                 if "start" in window and "end" in window:
                     backup_start = self._convert_str_datetime_to_epoch(window["start"])
                     backup_end = self._convert_str_datetime_to_epoch(window["end"])

--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -341,10 +341,18 @@ class LLM(Parser):
                 "type": "string",
             }
         }
+        "backup_windows": {
+            type: "array",
+            "items": {
+                "type": "datetime",
+            }
+        }
     }
     More context:
     * Circuit IDs are also known as service or order
     * Status could be confirmed, ongoing, cancelled, completed or rescheduled
+    * If you see any other backup windows, create a new list entry for each pair of start/end seen there.
+    * If no backup windows are found. leave the backup_windows list empty.
     """
 
     def parser_hook(self, raw: bytes, content_type: str):
@@ -487,7 +495,10 @@ class LLM(Parser):
 
         impact = self._get_impact(generated_json)
 
-        data = {
+        # Main maintenance entry
+        data_list = []
+
+        main_data = {
             "circuits": self._get_circuit_ids(generated_json, impact),
             "start": int(self._get_start(generated_json)),
             "end": int(self._get_end(generated_json)),
@@ -496,17 +507,47 @@ class LLM(Parser):
             "account": str(self._get_account(generated_json)),
         }
 
-        data["maintenance_id"] = str(
+        # Generate maintenance ID for main window
+        main_data["maintenance_id"] = str(
             self._get_maintenance_id(
                 generated_json,
-                data["start"],
-                data["end"],
-                data["circuits"],
+                main_data["start"],
+                main_data["end"],
+                main_data["circuits"],
             )
         )
 
-        return [data]
+        data_list.append(main_data)
 
+        # Process backup windows
+        if "backup_windows" in generated_json:
+            for window in generated_json["backup_windows"]:
+                if "start" in window and "end" in window:
+                    backup_start = self._convert_str_datetime_to_epoch(window["start"])
+                    backup_end = self._convert_str_datetime_to_epoch(window["end"])
+
+                    backup_data = {
+                        "circuits": main_data["circuits"],  # Same circuits
+                        "start": backup_start,
+                        "end": backup_end,
+                        "summary": main_data["summary"],
+                        "status": main_data["status"],
+                        "account": main_data["account"],
+                    }
+
+                    # Generate a new maintenance ID for the backup window
+                    backup_data["maintenance_id"] = str(
+                        self._get_maintenance_id(
+                            generated_json,
+                            backup_start,
+                            backup_end,
+                            backup_data["circuits"],
+                        )
+                    )
+
+                    data_list.append(backup_data)
+
+        return data_list  # Returning a list with main and backup windows
 
 class Xlsx(Parser):
     """Xlsx parser."""


### PR DESCRIPTION
Noticed that the LLM cannot parse multiple windows as it has no where in the json to store that data. We need the LLM to extract the extra maintenance window values from the email, and store them somewhere in the return data so that the rest of the code knows that there should be multiple maintenances(windows) in the single email. I have done this below with the 'backup_windows' key which is a list. This list will contain all start/end pairs that the LLM can find, that are not the main window.
 
Had some discussions with @chadell via DM and discussed the possibility of doing this with the code changes below. Christian also mentioned the possibility of improving this to convert the entire parsing into a loop.

Creating this pull request so we can collaborate on these changes.