### PR TITLE
return proper impact result for LLM parsing

### DIFF
--- a/circuit_maintenance_parser/parser.py
+++ b/circuit_maintenance_parser/parser.py
@@ -353,6 +353,7 @@ class LLM(Parser):
     * Status could be confirmed, ongoing, cancelled, completed or rescheduled
     * If you see any other backup windows, create a new list entry for each pair of start/end seen there.
     * If no backup windows are found. leave the backup_windows list empty.
+    * Impact should be returned as either "no impact", "partial" or "outage" depending on which best represents the impact information in the email.
     """
 
     def parser_hook(self, raw: bytes, content_type: str):


### PR DESCRIPTION
I’ve been testing some more with the LLM and noticed some things which I can recommend to you if you wanted to make changes to the LLM question initially asked.

Impact value returned:
I’ve noticed that when the LLM is parsing an email, it can accurately determine the impact of a maintenance which is great. However, the generated_json from the llm will literally return a string of the impact from the email. In my case, I tested with a Tampnet email, and in their impact statement they literally write “NO-IMPACT”. This is what is returned in the generated_json from the LLM, but when you look at the data returned at the end of the process of structuring the metadata, my impact was equal to “OUTAGE”.

The reason the code does this is because of the section here:

```
    def _get_impact(self, generated_json: dict):
        """Method to get a general Impact for all Circuits."""
        impact_key = self.get_key_with_string(generated_json, "impact")
        if impact_key:
            if "no impact" in generated_json[impact_key].lower():
                return Impact.NO_IMPACT
            if "partial" in generated_json[impact_key].lower():
                return Impact.DEGRADED

        return Impact.OUTAGE
```


We need the LLM to return one of three results. “no impact”, “partial” or “outage”  - Or at least include one of those words once in the impact being returned.