### PR TITLE
Update AWS parser for HTML emails

### DIFF
--- a/circuit_maintenance_parser/parsers/aws.py
+++ b/circuit_maintenance_parser/parsers/aws.py
@@ -62,29 +62,62 @@ class TextParserAWS1(Text):
         """
         data = {"circuits": []}
         impact = Impact.OUTAGE
-        maintenace_id = ""
+        maintenance_id = ""
         status = Status.CONFIRMED
-        for line in text.splitlines():
-            if "planned maintenance" in line.lower() or "maintenance has been scheduled" in line.lower():
-                data["summary"] = line
-                search = re.search(
-                    r"([A-Z][a-z]{2}, [0-9]{1,2} [A-Z][a-z]{2,9} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{2,3}) to ([A-Z][a-z]{2}, [0-9]{1,2} [A-Z][a-z]{2,9} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{2,3})",
-                    line,
-                )
-                if search:
-                    data["start"] = self.dt2ts(parser.parse(search.group(1)))
-                    data["end"] = self.dt2ts(parser.parse(search.group(2)))
-                    maintenace_id += str(data["start"])
-                    maintenace_id += str(data["end"])
-                if "may become unavailable" in line.lower():
-                    impact = Impact.OUTAGE
-                elif "has been cancelled" in line.lower():
-                    status = Status.CANCELLED
-            elif re.match(r"[a-z]{5}-[a-z0-9]{8}", line):
-                maintenace_id += line
+        if re.search(r'<!doctype html>', text, re.IGNORECASE):
+            soup = bs4.BeautifulSoup(text, 'html.parser')
+            clean_string = soup.get_text()
+            clean_string = re.sub('=20', '', clean_string)
+            clean_list = clean_string.splitlines()
+            cleaner_list = []
+            for line in clean_list:
+                newline = line.strip()
+                if newline != "":
+                    cleaner_list.append(newline)
+            sumstart = cleaner_list.index('Hello,')
+            try:
+                sumend = cleaner_list.index('[1] https://aws.amazon.com/support')
+            except ValueError:
+                sumend = len(cleaner_list)
+            summary = ""
+            for line in cleaner_list[sumstart:sumend]:
+                summary+=f"{line}\n"
+            if "may become unavailable" in summary.lower():
+                impact = Impact.OUTAGE
+            elif "has been cancelled" in summary.lower():
+                status = Status.CANCELLED
+            start_time = cleaner_list[cleaner_list.index('Start time')+1]
+            end_time = cleaner_list[cleaner_list.index('End time')+1]
+            data["start"] = self.dt2ts(parser.parse(start_time))
+            data["end"] = self.dt2ts(parser.parse(end_time))
+            data["summary"] = summary
+            for line in summary.splitlines():
+                line = line.strip()
+                maintenance_id += line
                 data["circuits"].append(CircuitImpact(circuit_id=line, impact=impact))
+            maintenance_id += str(data["start"])
+            maintenance_id += str(data["end"])
+        else:
+            for line in text.splitlines():
+                if "planned maintenance" in line.lower() or "maintenance has been scheduled" in line.lower():
+                    data["summary"] = line
+                    search = re.search(
+                        r"([A-Z][a-z]{2}, [0-9]{1,2} [A-Z][a-z]{2,9} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{2,3}) to ([A-Z][a-z]{2}, [0-9]{1,2} [A-Z][a-z]{2,9} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{2,3})",
+                        line,
+                    )
+                    if search:
+                        data["start"] = self.dt2ts(parser.parse(search.group(1)))
+                        data["end"] = self.dt2ts(parser.parse(search.group(2)))
+                        maintenance_id += str(data["start"])
+                        maintenance_id += str(data["end"])
+                    if "may become unavailable" in line.lower():
+                        impact = Impact.OUTAGE
+                    elif "has been cancelled" in line.lower():
+                        status = Status.CANCELLED
+                    maintenance_id += line
+                    data["circuits"].append(CircuitImpact(circuit_id=line, impact=impact))
         # No maintenance ID found in emails, so a hash value is being generated using the start,
         #  end and IDs of all circuits in the notification.
-        data["maintenance_id"] = hashlib.sha256(maintenace_id.encode("utf-8")).hexdigest()  # nosec
+        data["maintenance_id"] = hashlib.sha256(maintenance_id.encode("utf-8")).hexdigest()  # nosec
         data["status"] = status
         return [data]


### PR DESCRIPTION
After updating the maintenance emails to go from AWS Health managed notifications they utilize an HTML format instead of plaintext. This was causing the parsing to fail. Adding support for the HTML emails from AWS health and maintaining previous code for plaintext (SNS) emails. 