### PR TITLE
Fix Lumen parser status for scheduled maintenance

### DIFF
--- a/changes/377.fixed.rst
+++ b/changes/377.fixed.rst
@@ -1,0 +1,1 @@
+Fixed Lumen parser incorrectly marking scheduled future maintenance events as IN-PROCESS instead of CONFIRMED. Bug introduced in commit 737aa4e9 (Aug 2021).

--- a/circuit_maintenance_parser/parsers/lumen.py
+++ b/circuit_maintenance_parser/parsers/lumen.py
@@ -60,11 +60,10 @@ class HtmlParserLumen1(Html):
                     for sibling in line.next_siblings:
                         text_sibling = sibling.text.strip() if isinstance(sibling, bs4.element.Tag) else sibling.strip()
                         if text_sibling != "":
-                            if (
-                                "This maintenance is scheduled" in text_sibling
-                                or "The scheduled maintenance work has begun" in text_sibling
-                            ):
+                            if "The scheduled maintenance work has begun" in text_sibling:
                                 data["status"] = Status("IN-PROCESS")
+                            elif "This maintenance is scheduled" in text_sibling:
+                                data["status"] = Status("CONFIRMED")
                             if "GMT" in text_sibling:
                                 stamp = parser.parse(text_sibling.split(" GMT")[0])
                                 data["stamp"] = self.dt2ts(stamp)

--- a/tests/unit/data/lumen/lumen3_result.json
+++ b/tests/unit/data/lumen/lumen3_result.json
@@ -11,7 +11,7 @@
         "maintenance_id": "987654321-1",
         "stamp": 1621494021,
         "start": 1621494000,
-        "status": "IN-PROCESS",
+        "status": "CONFIRMED",
         "summary": "Lumen intends to carry out internal maintenance within its network.  This has been designated as EMERGENCY.  The nature of this work is to replace faulty hardware and is required in order to improve network reliability and continue providing optimal service for our clients."
     }
 ]

--- a/tests/unit/data/lumen/lumen4_result.json
+++ b/tests/unit/data/lumen/lumen4_result.json
@@ -11,7 +11,7 @@
         "maintenance_id": "123456789",
         "stamp": 1628869538,
         "start": 1629950400,
-        "status": "IN-PROCESS",
+        "status": "CONFIRMED",
         "summary": "Lumen will implement scheduled maintenance as part of a large scale project to upgrade code on the IP platform. This maintenance activity is one of several maintenances taking place across various locations in multiple regions. The upgrade will mitigate an existing defect in the current software version and prevent future network outages."
     }
 ]

--- a/tests/unit/data/lumen/lumen8_result.json
+++ b/tests/unit/data/lumen/lumen8_result.json
@@ -15,7 +15,7 @@
         "maintenance_id": "12345678",
         "stamp": 1678379003,
         "start": 1679457600,
-        "status": "IN-PROCESS",
+        "status": "CONFIRMED",
         "summary": "Lumen intends to carry out internal maintenance within its network.  This has been designated as ESSENTIAL. The nature of this work is to repair fiber and is required in order to avoid unplanned outages from damages related to natural causes."
     },
     {
@@ -34,7 +34,7 @@
         "maintenance_id": "12345678",
         "stamp": 1678379003,
         "start": 1679544000,
-        "status": "IN-PROCESS",
+        "status": "CONFIRMED",
         "summary": "Lumen intends to carry out internal maintenance within its network.  This has been designated as ESSENTIAL. The nature of this work is to repair fiber and is required in order to avoid unplanned outages from damages related to natural causes."
       }
 ]


### PR DESCRIPTION
Fixed a bug where scheduled future maintenance events were incorrectly being marked as IN-PROCESS instead of CONFIRMED.

The bug seems to have been introduced in commit 737aa4e9 (Aug 2021, PR #49 "Lumen Variations") when the parser logic was changed to set status to IN-PROCESS for emails containing either "The scheduled maintenance work has begun" OR "This maintenance is scheduled".

The fix separates these two conditions:
- "The scheduled maintenance work has begun" → IN-PROCESS (correct)
- "This maintenance is scheduled" → CONFIRMED (now correct)

Updated test expectations for lumen3, lumen4, and lumen8 which all contain "This maintenance is scheduled" text and represent future scheduled events.