### PR TITLE
Bump version to 2.11.1-beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "circuit-maintenance-parser"
-version = "2.11.0"
+version = "2.11.1b1"
 description = "Python library to parse Circuit Maintenance notifications and return a structured data back"
 authors = ["Network to Code <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Post-release version bump to `2.11.1-beta` on develop, per NTC release workflow.