### PR TITLE
Bump pytest to 9.0.3 (CVE-2025-71176)

### DIFF
--- a/changes/396.security
+++ b/changes/396.security
@@ -1,0 +1,1 @@
+Updated pytest to 9.0.3 to address CVE-2025-71176 (insecure /tmp/pytest-of-{user} tmpdir handling).

--- a/poetry.lock
+++ b/poetry.lock
@@ -2137,14 +2137,14 @@ extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Summary

- Bumps `pytest` from 9.0.2 to 9.0.3 in `poetry.lock` (cherry-picked from Renovate #396).
- Adds `changes/396.security` towncrier fragment — the missing piece that blocked Renovate's PR on the `changelog` check.

## Context

Addresses [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) / [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g) — insecure `/tmp/pytest-of-{user}` tmpdir handling on UNIX (local DoS / privilege escalation). CVSS 6.8 (Medium). Dev-dependency only.

Supersedes #396. Tracking: #403.

## Test plan

- [ ] `changelog` CI check passes (fragment present)
- [ ] `pytest` matrix passes across Python 3.10–3.13
- [ ] `poetry lock --check` passes