### PR TITLE
Bump pytest minimum to 9.0.3 (CVE-2025-71176)

### DIFF
--- a/changes/396.security
+++ b/changes/396.security
@@ -1,0 +1,1 @@
+Raised the minimum pytest version to 9.0.3 to address CVE-2025-71176 (insecure /tmp/pytest-of-{user} tmpdir handling on UNIX).

--- a/poetry.lock
+++ b/poetry.lock
@@ -2137,14 +2137,14 @@ extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
@@ -2787,4 +2787,4 @@ xlsx = ["openpyxl", "pandas"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "6bba954a14e852b48528814ed21319d92588272e02cf3769394bf50379acdb55"
+content-hash = "0f7895e0778609eff2dd15f16f1f958bb7abccfc61c054b470967886e07b1eeb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ openai = [
 ]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^9.0.0"
+pytest = "^9.0.3"
 requests_mock = "^1.7.0"
 pyyaml = "^6.0"
 pylint = "^4.0.0"


### PR DESCRIPTION
## Summary

- Raises the minimum `pytest` constraint from `^9.0.0` to `^9.0.3` in `pyproject.toml` so consumers of this library and its dev environment can't install a vulnerable pytest.
- Refreshes `poetry.lock` (pytest `9.0.2` → `9.0.3`).
- Adds `changes/396.security` towncrier fragment.

## Context

Addresses [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) / [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g) — insecure `/tmp/pytest-of-{user}` tmpdir handling on UNIX (local DoS / privilege escalation). CVSS 6.8 (Medium). Dev-dependency only.

Supersedes #396 (Renovate's lockfile-only bump, blocked on `changelog` check).